### PR TITLE
Optimization: flow the Receiver runtime info as part of EventData

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -15,6 +15,7 @@ public final class EventProcessorOptions
 {
 	private Consumer<ExceptionReceivedEventArgs> exceptionNotificationHandler = null;
     private Boolean invokeProcessorAfterReceiveTimeout = false;
+    private boolean receiverRuntimeMetricEnabled = false;
     private int maxBatchSize = 10;
     private int prefetchCount = 300;
     private Duration receiveTimeOut = Duration.ofMinutes(1);
@@ -30,6 +31,7 @@ public final class EventProcessorOptions
      * PrefetchCount: 300
      * InitialOffsetProvider: uses the last offset checkpointed, or START_OF_STREAM
      * InvokeProcessorAfterReceiveTimeout: false
+     * ReceiverRuntimeMetricEnabled: false
      * </pre>
      * 
      * @return an EventProcessorOptions instance with all options set to the default values
@@ -169,6 +171,32 @@ public final class EventProcessorOptions
     public void setInvokeProcessorAfterReceiveTimeout(Boolean invokeProcessorAfterReceiveTimeout)
     {
         this.invokeProcessorAfterReceiveTimeout = invokeProcessorAfterReceiveTimeout;
+    }
+    
+    /**
+     * Knob to enable/disable runtime metric of the receiver. If this is set to true, 
+     * the first parameter {@link com.microsoft.azure.eventprocessorhost.PartitionContext#runtimeInformation} of
+     * {@link IEventProcessor#onEvents(com.microsoft.azure.eventprocessorhost.PartitionContext, java.lang.Iterable)} will be populated.
+     * <p>
+     * Enabling this knob will add 3 additional properties to all raw AMQP messages received.
+     * @return the {@link boolean} indicating, whether, the runtime metric of the receiver was enabled
+     */
+    public boolean getReceiverRuntimeMetricEnabled()
+    {
+        return this.receiverRuntimeMetricEnabled;
+    }
+    
+    /**
+     * Knob to enable/disable runtime metric of the receiver. If this is set to true, 
+     * the first parameter {@link com.microsoft.azure.eventprocessorhost.PartitionContext#runtimeInformation} of
+     * {@link IEventProcessor#onEvents(com.microsoft.azure.eventprocessorhost.PartitionContext, java.lang.Iterable)} will be populated.
+     * <p>
+     * Enabling this knob will add 3 additional properties to all raw AMQP messages received.
+     * @param value the {@link boolean} to indicate, whether, the runtime metric of the receiver should be enabled
+     */
+    public void setReceiverRuntimeMetricEnabled(boolean value)
+    {
+        this.receiverRuntimeMetricEnabled = value;
     }
 
     void notifyOfException(String hostname, Exception exception, String action)

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -12,17 +12,19 @@ import java.util.logging.Level;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.PartitionReceiver;
+import com.microsoft.azure.eventhubs.ReceiverRuntimeInformation;
 
 public class PartitionContext
 {
-	private final EventProcessorHost host;
+    private final EventProcessorHost host;
     private final String partitionId;
     private final String eventHubPath;
     private final String consumerGroupName;
     
     private Lease lease;
     private String offset = PartitionReceiver.START_OF_STREAM;
-    private long sequenceNumber = 0;;
+    private long sequenceNumber = 0;
+    private ReceiverRuntimeInformation runtimeInformation;
     
     private Object offsetSynchronizer;
     
@@ -49,6 +51,16 @@ public class PartitionContext
     public String getOwner()
     {
     	return this.lease.getOwner();
+    }
+    
+    public ReceiverRuntimeInformation getRuntimeInformation()
+    {
+        return this.runtimeInformation;
+    }
+    
+    void setRuntimeInformation(ReceiverRuntimeInformation value)
+    {
+        this.runtimeInformation = value;
     }
 
     Lease getLease()

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
@@ -43,6 +43,9 @@ public class PrefabEventProcessor implements IEventProcessor
 	{
 		int batchSize = 0;
 		EventData lastEvent = null;
+                if (messages != null && messages.iterator().hasNext())
+                    this.factory.setOnEventsContext(context);
+                
 		for (EventData event : messages)
 		{
 			this.eventCount++;

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
@@ -18,6 +18,7 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	private ArrayList<String> errors = new ArrayList<String>();
 	private HashMap<String, Boolean> foundTelltale = new HashMap<String, Boolean>(); 
 	private int eventsReceivedCount = 0;
+        private PartitionContext partitionContextOnEvents;
 	
 	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker)
 	{
@@ -72,6 +73,16 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	{
 		return this.eventsReceivedCount;
 	}
+        
+        PartitionContext getOnEventsContext()
+        {
+            return this.partitionContextOnEvents;
+        }
+        
+        void setOnEventsContext(PartitionContext value)
+        {
+            this.partitionContextOnEvents = value;
+        }
 
 	@Override
 	public IEventProcessor createEventProcessor(PartitionContext context) throws Exception

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
@@ -5,14 +5,13 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import static org.junit.Assert.*;
-
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
+import org.junit.Assert;
 import org.junit.Test;
 
 import com.microsoft.azure.eventhubs.EventData;
@@ -32,6 +31,19 @@ public class SmokeTest extends TestBase
 		waitForTelltale(settings);
 
 		testFinish(settings, SmokeTest.ANY_NONZERO_COUNT);
+	}
+        
+        @Test
+	public void ReceiverRuntimeMetricsTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("ReceiverRuntimeMetrics");
+                settings.inOptions.setReceiverRuntimeMetricEnabled(true);
+		settings = testSetup(settings); 
+
+		settings.outUtils.sendToAny(settings.outTelltale);
+		waitForTelltale(settings);
+
+		Assert.assertTrue(settings.outProcessorFactory.getOnEventsContext().getRuntimeInformation() != null);
 	}
 	
 	@Test

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataUtil.java
@@ -14,12 +14,13 @@ import java.util.function.Consumer;
 import org.apache.qpid.proton.message.Message;
 
 import com.microsoft.azure.servicebus.amqp.AmqpConstants;
+import com.microsoft.azure.servicebus.PassByRef;
 
 /*
  * Internal utility class for EventData
  */
-final class EventDataUtil
-{
+final class EventDataUtil {
+    
 	@SuppressWarnings("serial")
 	static final Set<String> RESERVED_SYSTEM_PROPERTIES = Collections.unmodifiableSet(new HashSet<String>()
 			{{
@@ -32,31 +33,30 @@ final class EventDataUtil
 	
 	private EventDataUtil(){}
 
-	static LinkedList<EventData> toEventDataCollection(final Collection<Message> messages)
-	{
-		if (messages == null)
-		{
+	static LinkedList<EventData> toEventDataCollection(final Collection<Message> messages, final PassByRef<Message> lastMessageRef) {
+            
+		if (messages == null) {
 			return null;
 		}
 
-		// TODO: no-copy solution
-		LinkedList<EventData> events = new LinkedList<EventData>();
-		for(Message message : messages)
-		{
+		LinkedList<EventData> events = new LinkedList<>();
+                for (Message message : messages) {
+                    
 			events.add(new EventData(message));
-		}
+                        
+                        if (lastMessageRef != null)
+                            lastMessageRef.set(message);
+                }
 
 		return events;
 	}
 
-	static Iterable<Message> toAmqpMessages(final Iterable<EventData> eventDatas, final String partitionKey)
-	{
-		final LinkedList<Message> messages = new LinkedList<Message>();
-		eventDatas.forEach(new Consumer<EventData>()
-		{
+	static Iterable<Message> toAmqpMessages(final Iterable<EventData> eventDatas, final String partitionKey) {
+            
+		final LinkedList<Message> messages = new LinkedList<>();
+		eventDatas.forEach(new Consumer<EventData>() {
 			@Override
-			public void accept(EventData eventData)
-			{				
+			public void accept(EventData eventData) {				
 				Message amqpMessage = partitionKey == null ? eventData.toAmqpMessage() : eventData.toAmqpMessage(partitionKey);
 				messages.add(amqpMessage);
 			}
@@ -65,8 +65,8 @@ final class EventDataUtil
 		return messages;
 	}
 
-	static Iterable<Message> toAmqpMessages(final Iterable<EventData> eventDatas)
-	{
+	static Iterable<Message> toAmqpMessages(final Iterable<EventData> eventDatas) {
+            
 		return EventDataUtil.toAmqpMessages(eventDatas, null);
 	}
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -626,7 +626,7 @@ public class EventHubClient extends ClientEntity
 	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
 	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
 	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-	 * @return                     a CompletableFuture that would result in a PartitionReceiver isntance when it is completed.
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
 	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
 	 * @see PartitionReceiver
 	 */
@@ -694,7 +694,7 @@ public class EventHubClient extends ClientEntity
 	public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive) 
 			throws ServiceBusException
 	{
-		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, PartitionReceiver.NULL_EPOCH, false);
+		return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, null);
 	}
 
 	/**
@@ -753,9 +753,198 @@ public class EventHubClient extends ClientEntity
 	public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime)
 			throws ServiceBusException
 	{
-		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, PartitionReceiver.NULL_EPOCH, false);
+		return this.createReceiver(consumerGroupName, partitionId, dateTime, null);
 	}
 
+        /**
+	 * Synchronous version of {@link #createReceiver(String, String, String)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+         * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createReceiver(consumerGroupName, partitionId, startingOffset, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * The receiver is created for a specific EventHub partition from the specific consumer group.
+	 * 
+	 * <p>NOTE: There can be a maximum number of receivers that can run in parallel per ConsumerGroup per Partition. 
+	 * The limit is enforced by the Event Hub service - current limit is 5 receivers in parallel. Having multiple receivers 
+	 * reading from offsets that are far apart on the same consumer group / partition combo will have significant performance Impact.   
+	 * 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 */
+	public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		return this.createReceiver(consumerGroupName, partitionId, startingOffset, false, receiverOptions);
+	}
+
+	/**
+	 * Synchronous version of {@link #createReceiver(String, String, String, boolean)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+	 * @param offsetInclusive      if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create the EventHub receiver with given partition id and start receiving from the specified starting offset.
+	 * The receiver is created for a specific EventHub Partition from the specific consumer group.
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+	 * @param offsetInclusive      if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 */
+	public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, PartitionReceiver.NULL_EPOCH, false, receiverOptions);
+	}
+
+	/**
+	 * Synchronous version of {@link #createReceiver(String, String, Instant)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param dateTime             the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createReceiver(consumerGroupName, partitionId, dateTime, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create the EventHub receiver with given partition id and start receiving from the specified starting offset.
+	 * The receiver is created for a specific EventHub Partition from the specific consumer group.
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param dateTime             the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 */	
+	public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final ReceiverOptions receiverOptions)
+			throws ServiceBusException
+	{
+		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, PartitionReceiver.NULL_EPOCH, false, receiverOptions);
+	}
+        
 	/**
 	 * Synchronous version of {@link #createEpochReceiver(String, String, String, long)}. 
 	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
@@ -893,7 +1082,7 @@ public class EventHubClient extends ClientEntity
 	public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch)
 			throws ServiceBusException
 	{
-		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, epoch, true);
+		return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch, null);
 	}
 
 	/**
@@ -962,7 +1151,222 @@ public class EventHubClient extends ClientEntity
 	public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch)
 			throws ServiceBusException
 	{
-            return PartitionReceiver.create(this.underlyingFactory,  this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, epoch, true);
+            return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch, null);
+	}
+
+	/**
+	 * Synchronous version of {@link #createEpochReceiver(String, String, String, long)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+	 * @param epoch                an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, epoch, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
+	 * The receiver is created for a specific EventHub Partition from the specific consumer group.
+	 * <p> 
+	 * It is important to pay attention to the following when creating epoch based receiver:
+	 * <ul>
+	 * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
+	 * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
+	 * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
+	 * </ul>
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+	 * @param epoch                an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 * @see ReceiverDisconnectedException
+	 */	
+	public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch, final ReceiverOptions receiverOptions)
+			throws ServiceBusException
+	{
+		return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, false, epoch, receiverOptions);
+	}
+
+	/**
+	 * Synchronous version of {@link #createEpochReceiver(String, String, String, boolean, long)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}     
+	 * @param offsetInclusive      if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+	 * @param epoch                an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
+	 * The receiver is created for a specific EventHub Partition from the specific consumer group.
+	 * <p> 
+	 * It is important to pay attention to the following when creating epoch based receiver:
+	 * <ul>
+	 * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
+	 * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
+	 * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
+	 * </ul>
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param startingOffset       the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}     
+	 * @param offsetInclusive      if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+	 * @param epoch                an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 * @see ReceiverDisconnectedException
+	 */	
+	public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch, final ReceiverOptions receiverOptions)
+			throws ServiceBusException
+	{
+		return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, epoch, true, receiverOptions);
+	}
+
+	/**
+	 * Synchronous version of {@link #createEpochReceiver(String, String, Instant, long)}. 
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param dateTime             the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
+	 * @param epoch                an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     PartitionReceiver instance which can be used for receiving {@link EventData}.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 */
+	public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch, final ReceiverOptions receiverOptions) 
+			throws ServiceBusException
+	{
+		try
+		{
+			return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch, receiverOptions).get();
+		}
+		catch (InterruptedException|ExecutionException exception)
+		{
+			if (exception instanceof InterruptedException)
+			{
+				// Re-assert the thread's interrupted status
+				Thread.currentThread().interrupt();
+			}
+
+			Throwable throwable = exception.getCause();
+			if (throwable != null)
+			{
+				if (throwable instanceof RuntimeException)
+				{
+					throw (RuntimeException)throwable;
+				}
+
+				if (throwable instanceof ServiceBusException)
+				{
+					throw (ServiceBusException)throwable;
+				}
+
+				throw new ServiceBusException(true, throwable);
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
+	 * The receiver is created for a specific EventHub Partition from the specific consumer group.
+	 * <p> 
+	 * It is important to pay attention to the following when creating epoch based receiver:
+	 * <ul>
+	 * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
+	 * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
+	 * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
+	 * </ul>
+	 * @param consumerGroupName    the consumer group name that this receiver should be grouped under.
+	 * @param partitionId          the partition Id that the receiver belongs to. All data received will be from this partition only.
+	 * @param dateTime             the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
+	 * @param epoch                a unique identifier (epoch value) that the service uses, to enforce partition/lease ownership. 
+	 * @param receiverOptions      the set of options to enable on the event hubs receiver
+	 * @return                     a CompletableFuture that would result in a PartitionReceiver when it is completed.
+	 * @throws ServiceBusException if Service Bus service encountered problems during the operation.
+	 * @see PartitionReceiver
+	 * @see ReceiverDisconnectedException
+	 */	
+	public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch, final ReceiverOptions receiverOptions)
+			throws ServiceBusException
+	{
+            return PartitionReceiver.create(this.underlyingFactory,  this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, epoch, true, receiverOptions);
 	}
 
 	@Override

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -21,14 +22,15 @@ import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.UnknownDescribedType;
 import org.apache.qpid.proton.message.Message;
 
+import com.microsoft.azure.servicebus.amqp.AmqpConstants;
 import com.microsoft.azure.servicebus.ClientConstants;
 import com.microsoft.azure.servicebus.ClientEntity;
 import com.microsoft.azure.servicebus.IReceiverSettingsProvider;
 import com.microsoft.azure.servicebus.MessageReceiver;
 import com.microsoft.azure.servicebus.MessagingFactory;
+import com.microsoft.azure.servicebus.PassByRef;
 import com.microsoft.azure.servicebus.ServiceBusException;
 import com.microsoft.azure.servicebus.StringUtil;
-import com.microsoft.azure.servicebus.amqp.AmqpConstants;
 
 /**
  * This is a logical representation of receiving from a EventHub partition.
@@ -69,6 +71,8 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 	private Long epoch;
 	private boolean isEpochReceiver;
 	private ReceivePump receivePump;
+        private ReceiverOptions receiverOptions;
+        private ReceiverRuntimeInformation runtimeInformation;
 	
 	private PartitionReceiver(MessagingFactory factory, 
 			final String eventHubName, 
@@ -95,7 +99,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 		this.receiveHandlerLock = new Object();
 	}
 
-	static CompletableFuture<PartitionReceiver> create(MessagingFactory factory, 
+        static CompletableFuture<PartitionReceiver> create(MessagingFactory factory, 
 			final String eventHubName, 
 			final String consumerGroupName, 
 			final String partitionId, 
@@ -103,7 +107,8 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 			final boolean offsetInclusive,
 			final Instant dateTime,
 			final long epoch,
-			final boolean isEpochReceiver) 
+			final boolean isEpochReceiver,
+                        final ReceiverOptions receiverOptions) 
 					throws ServiceBusException
 	{
 		if (epoch < NULL_EPOCH)
@@ -117,7 +122,8 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 		}
 
 		final PartitionReceiver receiver = new PartitionReceiver(factory, eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, dateTime, epoch, isEpochReceiver);
-		return receiver.createInternalReceiver().thenApplyAsync(new Function<Void, PartitionReceiver>()
+		receiver.receiverOptions = receiverOptions;
+                return receiver.createInternalReceiver().thenApplyAsync(new Function<Void, PartitionReceiver>()
 		{
 			public PartitionReceiver apply(Void a)
 			{
@@ -207,6 +213,17 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 	{
 		return this.epoch;
 	}
+        
+        /**
+         * Gets the temporal {@link ReceiverRuntimeInformation} for this EventHub partition.
+         * In general, this information is a representation of, where this {@link PartitionReceiver}'s end of stream is,
+         * at the time {@link ReceiverRuntimeInformation#getRetrievalTime()}.
+         * @return receiver runtime information
+         */
+        public final ReceiverRuntimeInformation getRuntimeInformation() {
+            
+            return this.runtimeInformation;
+        }
 
 	/**
 	 * Synchronous version of {@link #receive}. 
@@ -288,7 +305,28 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 			@Override
 			public Iterable<EventData> apply(Collection<Message> amqpMessages)
 			{
-				return EventDataUtil.toEventDataCollection(amqpMessages);
+                                PassByRef<Message> lastMessageRef = null;
+                                if (PartitionReceiver.this.receiverOptions != null && PartitionReceiver.this.receiverOptions.getReceiverRuntimeMetricEnabled())
+                                   lastMessageRef = new PassByRef<>();
+                                
+				Iterable<EventData> events = EventDataUtil.toEventDataCollection(amqpMessages, lastMessageRef);
+                                
+                                if (lastMessageRef != null && lastMessageRef.get() != null) {
+                                    
+                                    if (PartitionReceiver.this.runtimeInformation == null)
+                                        PartitionReceiver.this.runtimeInformation = new ReceiverRuntimeInformation(PartitionReceiver.this.partitionId);
+                                    
+                                    if (lastMessageRef.get().getDeliveryAnnotations() != null && lastMessageRef.get().getDeliveryAnnotations().getValue() != null) {
+                                        
+                                        Map<Symbol, Object> deliveryAnnotationsMap = lastMessageRef.get().getDeliveryAnnotations().getValue();
+                                        PartitionReceiver.this.runtimeInformation.setRuntimeInformation(
+                                                (long) deliveryAnnotationsMap.get(ClientConstants.LAST_ENQUEUED_SEQUENCE_NUMBER),
+                                                ((Date) deliveryAnnotationsMap.get(ClientConstants.LAST_ENQUEUED_TIME_UTC)).toInstant(),
+                                                (String) deliveryAnnotationsMap.get(ClientConstants.LAST_ENQUEUED_OFFSET));
+                                    }
+                                }
+                                
+                                return events;
 			}
 		});
 	}
@@ -443,8 +481,16 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 	}
 
 	@Override
-	public Map<Symbol, Object> getProperties()
-	{
-		return this.isEpochReceiver ? Collections.singletonMap(AmqpConstants.EPOCH, (Object) this.epoch) : null;
+	public Map<Symbol, Object> getProperties() {
+            
+            return this.isEpochReceiver ? Collections.singletonMap(AmqpConstants.EPOCH, (Object) this.epoch) : null;
 	}
+
+        @Override
+        public Symbol[] getDesiredCapabilities() {
+
+            return this.receiverOptions != null && this.receiverOptions.getReceiverRuntimeMetricEnabled()
+                    ? new Symbol[] { AmqpConstants.ENABLE_RECEIVER_RUNTIME_METRIC_NAME }
+                    : null;
+        }
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverOptions.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverOptions.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs;
+
+/**
+ * Represents various optional behaviors which can be turned on or off during the creation of a {@link PartitionReceiver}.
+ */
+public final class ReceiverOptions {
+    
+    private boolean receiverRuntimeMetricEnabled;
+    
+    /**
+     * Knob to enable/disable runtime metric of the receiver. If this is set to true and is passed to {@link EventHubClient#createReceiver(...)},
+     * after the first {@link PartitionReceiver#receive(int)} call, {@link PartitionReceiver#getRuntimeInfo()} is populated.
+     * <p>
+     * Enabling this knob will add 3 additional properties to all {@link EventData}'s received on the {@link EventHubClient#createReceiver(...)}.
+     * @return the {@link boolean} indicating, whether, the runtime metric of the receiver was enabled
+     */
+    public boolean getReceiverRuntimeMetricEnabled() {
+        
+        return this.receiverRuntimeMetricEnabled;
+    }
+    
+    /**
+     * Knob to enable/disable runtime metric of the receiver. If this is set to true and is passed to {@link EventHubClient#createReceiver(...)},
+     * after the first {@link PartitionReceiver#receive(int)} call, {@link PartitionReceiver#getRuntimeInfo()} is populated.
+     * <p>
+     * Enabling this knob will add 3 additional properties to all {@link EventData}'s received on the {@link EventHubClient#createReceiver(...)}.
+     * @param value the {@link boolean} to indicate, whether, the runtime metric of the receiver should be enabled
+     */
+    public void setReceiverRuntimeMetricEnabled(boolean value) {
+        
+        this.receiverRuntimeMetricEnabled = value;
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverRuntimeInformation.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverRuntimeInformation.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs;
+
+import java.time.Instant;
+
+/**
+ * Represents the temporal receiver runtime information for a {@link PartitionReceiver}.
+ * Current received {@link EventData} and {@link ReceiverRuntimeInformation} can be used to find approximate value of pending events (which are not processed yet).
+ */
+public final class ReceiverRuntimeInformation {
+    
+    private final String partitionId;
+    
+    private long lastSequenceNumber;
+    private Instant lastEnqueuedTime;
+    private String lastEnqueuedOffset;
+    private Instant retrievalTime;
+    
+    public ReceiverRuntimeInformation(final String partitionId) {
+        
+        this.partitionId = partitionId;
+    }
+    
+    /**
+     * Get PartitionId of the {@link PartitionReceiver} for which the {@link ReceiverRuntimeInformation} is returned.
+     * @return Partition Identifier
+     */
+    public String getPartitionId() {
+        
+        return this.partitionId;
+    }
+    
+    /**
+     * Get sequence number of the {@link EventData}, that is written at the end of the Partition Stream.
+     * @return last sequence number
+     */
+    public long getLastSequenceNumber() {
+        
+        return this.lastSequenceNumber;
+    }
+    
+    /**
+     * Get enqueued time of the {@link EventData}, that is written at the end of the Partition Stream.
+     * @return last enqueued time
+     */
+    public Instant getLastEnqueuedTime() {
+        
+        return this.lastEnqueuedTime;
+    }
+    
+    /**
+     * Get offset of the {@link Eventdata}, that is written at the end of the Partition Stream.
+     * @return last enqueued offset
+     */
+    public String getLastEnqueuedOffset() {
+        
+        return this.lastEnqueuedOffset;
+    }
+    
+    /**
+     * Get the timestamp at which this {@link ReceiverRuntimeInformation} was constructed.
+     * @return retrieval time
+     */
+    public Instant getRetrievalTime() {
+        
+        return this.retrievalTime;
+    }
+    
+    void setRuntimeInformation(final long sequenceNumber, final Instant enqueuedTime, final String offset) {
+        
+        this.lastSequenceNumber = sequenceNumber;
+        this.lastEnqueuedTime = enqueuedTime;
+        this.lastEnqueuedOffset = offset;
+        
+        this.retrievalTime = Instant.now();
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -52,7 +52,7 @@ public final class ClientConstants
 	public final static String DEFAULT_RETRY = "Default";
 	
 	public final static String PRODUCT_NAME = "MSJavaClient";
-	public final static String CURRENT_JAVACLIENT_VERSION = "0.11.0";
+	public final static String CURRENT_JAVACLIENT_VERSION = "0.12.0-SNAPSHOT";
 
 	public static final String PLATFORM_INFO = getPlatformInfo();
         
@@ -84,6 +84,10 @@ public final class ClientConstants
         public static final String MANAGEMENT_STATUS_CODE_KEY = "status-code";
         public static final String MANAGEMENT_STATUS_DESCRIPTION_KEY = "status-description";
         public static final String MANAGEMENT_RESPONSE_ERROR_CONDITION = "error-condition";
+        
+        public static final Symbol LAST_ENQUEUED_SEQUENCE_NUMBER = Symbol.valueOf(MANAGEMENT_RESULT_LAST_ENQUEUED_SEQUENCE_NUMBER);
+        public static final Symbol LAST_ENQUEUED_OFFSET = Symbol.valueOf(MANAGEMENT_RESULT_LAST_ENQUEUED_OFFSET);
+        public static final Symbol LAST_ENQUEUED_TIME_UTC = Symbol.valueOf(MANAGEMENT_RESULT_LAST_ENQUEUED_TIME_UTC);
         
         public static final String AMQP_PUT_TOKEN_FAILED_ERROR = "Put token failed. status-code: %s, status-description: %s";
         public static final String TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/IReceiverSettingsProvider.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/IReceiverSettingsProvider.java
@@ -15,4 +15,6 @@ public interface IReceiverSettingsProvider
 	public Map<Symbol, UnknownDescribedType> getFilter(final Message lastReceivedMessage);
 
 	public Map<Symbol, Object> getProperties();
+        
+        public Symbol[] getDesiredCapabilities();
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -520,11 +520,15 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                     // use explicit settlement via dispositions (not pre-settled)
                     receiver.setSenderSettleMode(SenderSettleMode.UNSETTLED);
                     receiver.setReceiverSettleMode(ReceiverSettleMode.SECOND);
-
+                    
                     final Map<Symbol, Object> linkProperties = MessageReceiver.this.settingsProvider.getProperties();
                     if (linkProperties != null)
                         receiver.setProperties(linkProperties);
 
+                    final Symbol[] desiredCapabilities = MessageReceiver.this.settingsProvider.getDesiredCapabilities();
+                    if (desiredCapabilities != null)
+                        receiver.setDesiredCapabilities(desiredCapabilities);
+                    
                     final ReceiveLinkHandler handler = new ReceiveLinkHandler(MessageReceiver.this);
                     BaseHandler.setHandler(receiver, handler);
                     MessageReceiver.this.underlyingFactory.registerForConnectionError(receiver);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/PassByRef.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/PassByRef.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.servicebus;
+
+public final class PassByRef<T extends Object> {
+    
+    T t;
+    
+    public T get() {
+        return this.t;
+    }
+    
+    public void set(final T t) {
+        this.t = t;
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/AmqpConstants.java
@@ -10,13 +10,12 @@ import java.util.Set;
 
 import org.apache.qpid.proton.amqp.Symbol;
 
-public final class AmqpConstants
-{
+public final class AmqpConstants {
+    
 	private AmqpConstants() { }
 
 	@SuppressWarnings("serial")
-	public static final Set<String> RESERVED_PROPERTY_NAMES = Collections.unmodifiableSet(new HashSet<String>()
-	{{
+	public static final Set<String> RESERVED_PROPERTY_NAMES = Collections.unmodifiableSet(new HashSet<String>() {{
 		add(AMQP_PROPERTY_MESSAGE_ID);
 		add(AMQP_PROPERTY_USER_ID);
 		add(AMQP_PROPERTY_TO);
@@ -71,4 +70,6 @@ public final class AmqpConstants
 	public static final String AMQP_PROPERTY_GROUP_ID = "group-id";
 	public static final String AMQP_PROPERTY_GROUP_SEQUENCE = "group-sequence";
 	public static final String AMQP_PROPERTY_REPLY_TO_GROUP_ID = "reply-to-group-id";
+        
+        public static final Symbol ENABLE_RECEIVER_RUNTIME_METRIC_NAME = Symbol.valueOf(VENDOR + ":enable-receiver-runtime-metric");
 }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverRuntimeMetricsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverRuntimeMetricsTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs.sendrecv;
+
+import java.time.Instant;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.PartitionReceiver;
+import com.microsoft.azure.eventhubs.ReceiverOptions;
+import com.microsoft.azure.eventhubs.lib.ApiTestBase;
+import com.microsoft.azure.eventhubs.lib.TestBase;
+import com.microsoft.azure.eventhubs.lib.TestContext;
+import com.microsoft.azure.servicebus.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.ServiceBusException;
+
+public class ReceiverRuntimeMetricsTest  extends ApiTestBase {
+    
+    static final String cgName = TestContext.getConsumerGroupName();
+    static final String partitionId = "0";
+    static final Instant beforeTestStart = Instant.now();
+
+    static EventHubClient ehClient;
+
+    static PartitionReceiver receiverWithOptions = null;
+    static PartitionReceiver receiverWithoutOptions = null;
+    static PartitionReceiver receiverWithOptionsDisabled = null;
+
+    @BeforeClass
+    public static void initializeEventHub()  throws Exception {
+        
+        final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+        ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString());
+        
+        ReceiverOptions options = new ReceiverOptions();
+        options.setReceiverRuntimeMetricEnabled(true);
+        
+        ReceiverOptions optionsWithMetricsDisabled = new ReceiverOptions();
+        optionsWithMetricsDisabled.setReceiverRuntimeMetricEnabled(false);
+        
+        receiverWithOptions = ehClient.createReceiverSync(cgName, partitionId, Instant.now(), options);
+        receiverWithoutOptions = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
+        receiverWithOptionsDisabled = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH, optionsWithMetricsDisabled);
+        
+        TestBase.pushEventsToPartition(ehClient, partitionId, 25).get();
+        
+        receiverWithOptions.receiveSync(10);
+        receiverWithoutOptions.receiveSync(10);
+        receiverWithOptionsDisabled.receiveSync(10);
+    }
+
+    @Test()
+    public void testRuntimeMetricsReturnedWhenEnabled() throws ServiceBusException {
+
+        Assert.assertTrue(receiverWithOptions.getRuntimeInformation() != null);
+        Assert.assertTrue(receiverWithOptions.getRuntimeInformation().getLastEnqueuedTime().isAfter(beforeTestStart));
+    }
+
+    @Test()
+    public void testRuntimeMetricsWhenDisabled() throws ServiceBusException {
+
+        Assert.assertTrue(receiverWithOptionsDisabled.getRuntimeInformation() == null);
+    }
+    
+    @Test()
+    public void testRuntimeMetricsDefaultDisabled() throws ServiceBusException {
+
+        Assert.assertTrue(receiverWithoutOptions.getRuntimeInformation() == null);
+    }
+    
+    @AfterClass()
+    public static void cleanup() throws ServiceBusException {
+        
+        if (receiverWithOptions != null)
+            receiverWithOptions.closeSync();
+        
+        if (receiverWithoutOptions != null)
+            receiverWithoutOptions.closeSync();
+
+        if (receiverWithOptionsDisabled != null)
+            receiverWithOptionsDisabled.closeSync();
+        
+        if (ehClient != null)
+            ehClient.closeSync();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.16.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
-		<client-current-version>0.11.0</client-current-version>
+		<client-current-version>0.12.0-SNAPSHOT</client-current-version>
 	</properties>
 	
 	<build>


### PR DESCRIPTION
* Partition receiver runtime metrics aka EndOfStream info
* move cursor to 0.12.0-snapshot
* receiverruntimemetrics on PartitionReceiver + CIT
* receiver runtime metrics + cit - in eph
issue #39