### PR TITLE
Fix issue 58: deliver empty iterable to onEvents on timeout

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.eventprocessorhost;
 
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.logging.Level;
@@ -205,7 +206,17 @@ class EventHubPartitionPump extends PartitionPump
                     // get control back each time onEvents returns, and be able to receive a new batch of messages
                     // with which to make the next onEvents call. The pump gains nothing by running faster than onEvents.
 
-                    EventHubPartitionPump.this.onEvents(events);
+                    // The underlying client returns null if there are no events, but the contract for IEventProcessor
+                    // is different and is expecting an empty iterable if there are no events (and invoke processor after
+                    // receive timeout is turned on).
+                    
+                    Iterable<EventData> effectiveEvents = events;
+                    if (effectiveEvents == null)
+                    {
+                    	effectiveEvents = new ArrayList<EventData>();
+                    }
+                    
+                    EventHubPartitionPump.this.onEvents(effectiveEvents);
 		}
 
 		@Override

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -148,8 +148,8 @@ public final class EventProcessorOptions
     }
     
     /***
-     * Returns whether the EventProcessorHost will call IEventProcessor.onEvents(null) when a receive
-     * timeout occurs (true) or not (false).
+     * Returns whether the EventProcessorHost will call IEventProcessor.onEvents() with an empty iterable
+     * when a receive timeout occurs (true) or not (false).
      * 
      * Defaults to false.
      * 
@@ -161,8 +161,8 @@ public final class EventProcessorOptions
     }
 
     /**
-     * Changes whether the EventProcessorHost will call IEventProcessor.onEvents(null) when a receive
-     * timeout occurs (true) or not (false).
+     * Changes whether the EventProcessorHost will call IEventProcessor.onEvents() with an empty iterable
+     * when a receive timeout occurs (true) or not (false).
      * 
      * The default is false (no call).
      * 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/IEventProcessor.java
@@ -47,10 +47,14 @@ public interface IEventProcessor
     /**
      * Called by the processor host when a batch of events has arrived.
      * 
-     * This is where the real work of the event processor is done.
+     * This is where the real work of the event processor is done. It is normally called when one
+     * or more events have arrived. If the EventProcessorHost instance was set up with an EventProcessorOptions
+     * on which setInvokeProcessorAfterReceiveTimeout(true) has been called, then if a receive times out,
+     * it will be called with an empty iterable. By default this option is false and receive timeouts do not
+     * cause a call to this method.
      * 
      * @param context	Information about the partition.
-     * @param messages	The events to be processed.
+     * @param messages	The events to be processed. May be empty.
      * @throws Exception
      */
     public void onEvents(PartitionContext context, Iterable<EventData> messages) throws Exception;

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
@@ -10,6 +10,8 @@ public class PerTestSettings
 	EventProcessorOptions inOptions; // can be null
 	boolean inDoCheckpoint;
 	boolean inEntityDoesNotExist; // Prevents test code from doing certain checks that would fail on nonexistence before reaching product code.
+	boolean inTelltaleOnTimeout; // Generates an empty telltale string, which causes PrefabEventProcessor to trigger telltale on timeout.
+	boolean inHasSenders;
 	
 	PerTestSettings(String testName)
 	{
@@ -17,6 +19,8 @@ public class PerTestSettings
 		this.inOptions = EventProcessorOptions.getDefaultOptions();
 		this.inDoCheckpoint = false;
 		this.inEntityDoesNotExist = false;
+		this.inTelltaleOnTimeout = false;
+		this.inHasSenders = true;
 		
 		this.inoutEPHConstructorArgs = new EPHConstructorArgs();
 	}
@@ -52,6 +56,7 @@ public class PerTestSettings
 		static final int CHECKPOINT_MANAGER_OVERRIDE = 0x0400;
 		static final int LEASE_MANAGER_OVERRIDE = 0x0800;
 		static final int EXPLICIT_MANAGER = CHECKPOINT_MANAGER_OVERRIDE | LEASE_MANAGER_OVERRIDE;
+		static final int TELLTALE_ON_TIMEOUT = 0x1000;
 		
 		private int flags;
 		

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
@@ -16,6 +16,7 @@ public class PrefabEventProcessor implements IEventProcessor
 	private boolean doCheckpoint;
 	private boolean doMarker;
 	private boolean logEveryMessage;
+	private boolean telltaleOnTimeout;
 	
 	private int eventCount = 0;
 	
@@ -26,6 +27,7 @@ public class PrefabEventProcessor implements IEventProcessor
 		this.doCheckpoint = doCheckpoint;
 		this.doMarker = doMarker;
 		this.logEveryMessage = logEveryMessage;
+		this.telltaleOnTimeout = telltale.isEmpty();
 	}
 	
 	@Override
@@ -63,6 +65,19 @@ public class PrefabEventProcessor implements IEventProcessor
 				this.factory.setTelltaleFound(context.getPartitionId());
 			}
 			lastEvent = event;
+		}
+		if (batchSize == 0)
+		{
+			if (this.telltaleOnTimeout)
+			{
+				TestUtilities.log("P" + context.getPartitionId() + " got expected timeout");
+				this.factory.setTelltaleFound(context.getPartitionId());
+			}
+			else
+			{
+				TestUtilities.log("P" + context.getPartitionId() + " got UNEXPECTED timeout");
+				this.factory.putError("P" + context.getPartitionId() + " got UNEXPECTED timeout");
+			}
 		}
 		this.factory.addBatch(batchSize);
 		if (doCheckpoint)

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SmokeTest.java
@@ -113,6 +113,36 @@ public class SmokeTest extends TestBase
 	}
 	
 	@Test
+	public void receiveInvokeOnTimeout() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("receiveInvokeOnTimeout");
+		settings.inOptions.setInvokeProcessorAfterReceiveTimeout(true);
+		settings.inTelltaleOnTimeout = true;
+		settings.inHasSenders = false;
+		settings = testSetup(settings);
+		
+		waitForTelltale(settings, "0");
+		
+		testFinish(settings, SmokeTest.SKIP_COUNT_CHECK);
+	}
+	
+	@Test
+	public void receiveNotInvokeOnTimeout() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("receiveNotInvokeOnTimeout");
+		settings = testSetup(settings);
+
+		// Receive timeout is one minute. If event processor is invoked on timeout, it will
+		// record an error that will fail the case on shutdown.
+		Thread.sleep(120 * 1000);
+		
+		settings.outUtils.sendToAny(settings.outTelltale);
+		waitForTelltale(settings);
+		
+		testFinish(settings, SmokeTest.ANY_NONZERO_COUNT);
+	}
+	
+	@Test
 	public void receiveAllPartitionsTest() throws Exception
 	{
 		// Save "now" to avoid race with sender startup.


### PR DESCRIPTION
Change to match behavior of other clients: if EPH is set to invoke the event processor on receive timeout, deliver an empty iterable to the event processor when a timeout occurs, not null.