### PR TITLE
Add lease argument to ICheckpointManager.UpdateCheckpoint to avoid multiple EPH instances updating

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -69,12 +69,21 @@ public interface ICheckpointManager
     /***
      * Update the checkpoint in the store with the offset/sequenceNumber in the provided checkpoint.
      * 
-     * @param checkpoint  offset/sequeceNumber to update the store with.
+     * The lease argument is necessary to make the Azure Storage implementation work correctly. The
+     * Azure Storage implementation stores the checkpoint as part of the lease and we cannot completely
+     * hide the connection between the two. If you are doing an implementation which does not have this
+     * limitation, you are free to ignore the lease argument.
+     * 
+     * @param lease		  lease for the partition to be checkpointed.
+     * @param checkpoint  offset/sequenceNumber and partition id to update the store with.
      *   
      * @return  Void
      */
+    public Future<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint);
+    
+    @Deprecated
     public Future<Void> updateCheckpoint(Checkpoint checkpoint);
-
+    
     /***
      * Delete the stored checkpoint for the given partition. If there is no stored checkpoint for the
      * given partition, that is treated as success.

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -26,16 +26,12 @@ public class PartitionContext
     private long sequenceNumber = 0;
     private ReceiverRuntimeInformation runtimeInformation;
     
-    private Object offsetSynchronizer;
-    
     PartitionContext(EventProcessorHost host, String partitionId, String eventHubPath, String consumerGroupName)
     {
         this.host = host;
         this.partitionId = partitionId;
         this.eventHubPath = eventHubPath;
         this.consumerGroupName = consumerGroupName;
-        
-        this.offsetSynchronizer = new Object();
     }
 
     public String getConsumerGroupName()
@@ -74,27 +70,18 @@ public class PartitionContext
         this.lease = lease;
     }
 
-    @Deprecated
-    public void setOffsetAndSequenceNumber(EventData event) throws IllegalArgumentException
+    void setOffsetAndSequenceNumber(EventData event)
     {
-    	setOffsetAndSequenceNumber(event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber());
-    }
-    
-    @Deprecated
-    public void setOffsetAndSequenceNumber(String offset, long sequenceNumber) throws IllegalArgumentException
-    {
-    	synchronized (this.offsetSynchronizer)
-    	{
-    		if (sequenceNumber >= this.sequenceNumber)
-    		{
-    			this.offset = offset;
-    			this.sequenceNumber = sequenceNumber;
-    		}
-    		else
-    		{
-    			throw new IllegalArgumentException("new offset " + offset + "//" + sequenceNumber + " less than old " + this.offset + "//" + this.sequenceNumber);
-    		}
-    	}
+		if (sequenceNumber >= this.sequenceNumber)
+		{
+			this.offset = event.getSystemProperties().getOffset();
+			this.sequenceNumber = event.getSystemProperties().getSequenceNumber();
+		}
+		else
+		{
+			this.host.logWithHostAndPartition(Level.FINER, this.partitionId, "setOffsetAndSequenceNumber(" + event.getSystemProperties().getOffset() + "//" +
+					event.getSystemProperties().getSequenceNumber() + ") would move backwards, ignoring");
+		}
     }
     
     public String getPartitionId()
@@ -156,11 +143,7 @@ public class PartitionContext
     	// of events, and no other thread should be updating this PartitionContext, unless perhaps the
     	// event processor is itself multithreaded... Whether it's required or not, the amount of work
     	// required is trivial, so we might as well do it to be sure.
-    	Checkpoint capturedCheckpoint = null;
-    	synchronized (this.offsetSynchronizer)
-    	{
-    		capturedCheckpoint = new Checkpoint(this.partitionId, this.offset, this.sequenceNumber);
-    	}
+    	Checkpoint capturedCheckpoint = new Checkpoint(this.partitionId, this.offset, this.sequenceNumber);
     	persistCheckpoint(capturedCheckpoint);
     }
 
@@ -175,7 +158,6 @@ public class PartitionContext
      */
     public void checkpoint(EventData event) throws IllegalArgumentException, InterruptedException, ExecutionException
     {
-    	setOffsetAndSequenceNumber(event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber());
     	persistCheckpoint(new Checkpoint(this.partitionId, event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber()));
     }
     
@@ -184,24 +166,6 @@ public class PartitionContext
     	this.host.logWithHostAndPartition(Level.FINER, persistThis.getPartitionId(), "Saving checkpoint: " +
     			persistThis.getOffset() + "//" + persistThis.getSequenceNumber());
 		
-    	Checkpoint inStoreCheckpoint = this.host.getCheckpointManager().getCheckpoint(persistThis.getPartitionId()).get();
-    	if ((inStoreCheckpoint == null) || (persistThis.getSequenceNumber() >= inStoreCheckpoint.getSequenceNumber()))
-    	{
-        	if (inStoreCheckpoint == null)
-        	{
-        		inStoreCheckpoint = persistThis;
-        	}
-	    	inStoreCheckpoint.setOffset(persistThis.getOffset());
-	    	inStoreCheckpoint.setSequenceNumber(persistThis.getSequenceNumber());
-	        this.host.getCheckpointManager().updateCheckpoint(inStoreCheckpoint).get();
-    	}
-    	else
-    	{
-    		String msg = "Ignoring out of date checkpoint with offset " + persistThis.getOffset() + "/sequence number " + persistThis.getSequenceNumber() +
-        			" because current persisted checkpoint has higher offset " + inStoreCheckpoint.getOffset() +
-        			"/sequence number " + inStoreCheckpoint.getSequenceNumber(); 
-    		this.host.logWithHostAndPartition(Level.SEVERE, persistThis.getPartitionId(), msg);
-    		throw new IllegalArgumentException(msg);
-    	}
+        this.host.getCheckpointManager().updateCheckpoint(this.lease, persistThis).get();
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -137,6 +137,21 @@ abstract class PartitionPump
     
     protected void onEvents(Iterable<EventData> events)
 	{
+    	// Update offset and sequence number in the PartitionContext to support argument-less overload of PartitionContext.checkpoint()
+		if (events != null)
+		{
+    		Iterator<EventData> blah = events.iterator();
+    		EventData last = null;
+    		while (blah.hasNext())
+    		{
+    			last = blah.next();
+    		}
+    		if (last != null)
+    		{
+    			this.partitionContext.setOffsetAndSequenceNumber(last);
+    		}
+		}
+		
     	try
         {
         	// Synchronize to serialize calls to the processor.
@@ -146,22 +161,6 @@ abstract class PartitionPump
         	synchronized(this.processingSynchronizer)
         	{
         		this.processor.onEvents(this.partitionContext, events);
-        		
-        		if (events != null)
-        		{
-	        		Iterator<EventData> blah = events.iterator();
-	        		EventData last = null;
-	        		while (blah.hasNext())
-	        		{
-	        			last = blah.next();
-	        		}
-	        		if (last != null)
-	        		{
-	        			this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Updating offset in partition context with end of batch " +
-	        					last.getSystemProperties().getOffset() + "//" + last.getSystemProperties().getSequenceNumber());
-	        			this.partitionContext.setOffsetAndSequenceNumber(last);
-	        		}
-        		}
         	}
         }
         catch (Exception e)

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
@@ -139,8 +139,15 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     	return returnCheckpoint;
     }
 
+    @Deprecated
     @Override
     public Future<Void> updateCheckpoint(Checkpoint checkpoint)
+    {
+    	return null;
+    }
+    
+    @Override
+    public Future<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint)
     {
         return EventProcessorHost.getExecutorService().submit(() -> updateCheckpointSync(checkpoint.getPartitionId(), checkpoint.getOffset(), checkpoint.getSequenceNumber()));
     }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
@@ -8,7 +8,7 @@ public class PerTestSettings
 	// Properties which are inputs to test setup. Constructor sets up defaults, except for testName.
 	private String inTestName;
 	EventProcessorOptions inOptions; // can be null
-	boolean inDoCheckpoint;
+	PrefabEventProcessor.CheckpointChoices inDoCheckpoint;
 	boolean inEntityDoesNotExist; // Prevents test code from doing certain checks that would fail on nonexistence before reaching product code.
 	boolean inTelltaleOnTimeout; // Generates an empty telltale string, which causes PrefabEventProcessor to trigger telltale on timeout.
 	boolean inHasSenders;
@@ -17,7 +17,7 @@ public class PerTestSettings
 	{
 		this.inTestName = testName;
 		this.inOptions = EventProcessorOptions.getDefaultOptions();
-		this.inDoCheckpoint = false;
+		this.inDoCheckpoint = PrefabEventProcessor.CheckpointChoices.CKP_NONE;
 		this.inEntityDoesNotExist = false;
 		this.inTelltaleOnTimeout = false;
 		this.inHasSenders = true;

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabProcessorFactory.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProcessor>
 {
 	private String telltale;
-	private boolean doCheckpoint;
+	private PrefabEventProcessor.CheckpointChoices doCheckpoint;
 	private boolean doMarker;
 	private boolean logEveryMessage;
 	
@@ -20,12 +20,12 @@ public class PrefabProcessorFactory implements IEventProcessorFactory<IEventProc
 	private int eventsReceivedCount = 0;
         private PartitionContext partitionContextOnEvents;
 	
-	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker)
+	PrefabProcessorFactory(String telltale, PrefabEventProcessor.CheckpointChoices doCheckpoint, boolean doMarker)
 	{
 		this(telltale, doCheckpoint, doMarker, false);
 	}
 	
-	PrefabProcessorFactory(String telltale, boolean doCheckpoint, boolean doMarker, boolean logEveryMessage)
+	PrefabProcessorFactory(String telltale, PrefabEventProcessor.CheckpointChoices doCheckpoint, boolean doMarker, boolean logEveryMessage)
 	{
 		this.telltale = telltale;
 		this.doCheckpoint = doCheckpoint;

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
@@ -37,7 +37,7 @@ public class Repros extends TestBase
 		String telltale = "conflictingHosts-telltale-" + EventProcessorHost.safeCreateUUID();
 		String conflictingName = "conflictingHosts-NOTSAFE";
 		String storageName = conflictingName.toLowerCase() + EventProcessorHost.safeCreateUUID();
-		boolean doCheckpointing = false;
+		PrefabEventProcessor.CheckpointChoices doCheckpointing = PrefabEventProcessor.CheckpointChoices.CKP_NONE;
 		boolean doMarker = false;
 		
 		PrefabGeneralErrorHandler general1 = new PrefabGeneralErrorHandler();

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -89,7 +89,7 @@ public class TestBase
 			String effectiveStorageContainerName = settings.getTestName().toLowerCase() + "-" + EventProcessorHost.safeCreateUUID();
 			if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.STORAGE_CONTAINER_OVERRIDE))
 			{
-				effectiveStorageContainerName = settings.inoutEPHConstructorArgs.getStorageContainerName();
+				effectiveStorageContainerName = settings.inoutEPHConstructorArgs.getStorageContainerName().toLowerCase();
 			}
 			else
 			{
@@ -220,8 +220,15 @@ public class TestBase
 			return null;
 		}
 
+		@Deprecated
 		@Override
 		public Future<Void> updateCheckpoint(Checkpoint checkpoint)
+		{
+			return null;
+		}
+
+		@Override
+		public Future<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint)
 		{
 			return null;
 		}


### PR DESCRIPTION

## Description

Originally discovered in dotnet EPH, downloading the lease in UpdateCheckpoint could end up with multiple EPH instances operating on the same lease if another instance had recently stolen the lease. Normally this would be prevented because the lease tokens would be different, but downloading meant that the previous owner had the new token. Adding the lease argument means the previous owner will attempt the update with the old token and be properly denied in this scenario.
Finish deprecating PartitionContext.setOffsetAndSequenceNumber.
PartitionContext.checkpoint() now uses last offset of current event batch.


This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.