### PR TITLE
fix exception contract for link-detach error - this should be a transient error

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ExceptionUtil.java
@@ -84,11 +84,11 @@ final class ExceptionUtil
 		}
 		else if (errorCondition.getCondition() == AmqpErrorCode.AmqpLinkDetachForced)
 		{
-			return new ServiceBusException(false, new AmqpException(errorCondition));
+			return new ServiceBusException(true, new AmqpException(errorCondition));
 		}
 		else if (errorCondition.getCondition() == AmqpErrorCode.ResourceLimitExceeded)
 		{
-			return new ServiceBusException(false, new AmqpException(errorCondition));
+			return new QuotaExceededException(new AmqpException(errorCondition));
 		}
 
 		return new ServiceBusException(ClientConstants.DEFAULT_IS_TRANSIENT, errorCondition.getDescription());

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/QuotaExceededException.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/QuotaExceededException.java
@@ -10,4 +10,8 @@ public class QuotaExceededException  extends ServiceBusException {
         super(false, message);
     }
     
+    public QuotaExceededException(Throwable cause) {
+        super(false, cause);
+    }
+    
 }


### PR DESCRIPTION
Fix for issue #67 - EventHubs container closed errors should be transient