### PR TITLE
Fix issue 47: NPE when doing detailed logging in client

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -470,7 +470,18 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
 			
 			if(TRACE_LOGGER.isLoggable(Level.FINE))
 			{
-				TRACE_LOGGER.log(Level.FINE, String.format("receiverPath[%s], action[createReceiveLink], offset[%s], offsetInclusive[%s]", this.internalReceiver.getReceivePath(), lastReceivedOffset, offsetInclusiveFlag));
+				String logReceivePath = "";
+				if (this.internalReceiver == null)
+				{
+					// During startup, internalReceiver is still null. Need to handle this special case when logging during startup
+					// or the reactor thread crashes with NPE when calling internalReceiver.getReceivePath() and no receiving occurs.
+					logReceivePath = "receiverPath[RECEIVER IS NULL]";
+				}
+				else
+				{
+					logReceivePath = "receiverPath[" + this.internalReceiver.getReceivePath() + "]";
+				}
+				TRACE_LOGGER.log(Level.FINE, String.format("%s, action[createReceiveLink], offset[%s], offsetInclusive[%s]", logReceivePath, lastReceivedOffset, offsetInclusiveFlag));
 			}
 
 			filter =  new UnknownDescribedType(AmqpConstants.STRING_FILTER,


### PR DESCRIPTION
When doing detailed logging on startup, PartitionReceiver.getFilter() was calling this.internalReceiver.getReceivePath() to log the receive path, but internalReceiver was null. This caused in NPE which killed the reactor thread and prevented message flow.


This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.