### PR TITLE
Fix connection, link and timer object leaks after EntityClose & fix inaccurate timer issues

### DIFF
--- a/ConsumingEvents.md
+++ b/ConsumingEvents.md
@@ -30,7 +30,7 @@ following dependency declaration inside of your Maven project file:
     <dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs-clients</artifactId> 
-   		<version>0.13.0</version> 
+   		<version>0.13.1</version> 
    	</dependency>   
  ```
  

--- a/PublishingEvents.md
+++ b/PublishingEvents.md
@@ -12,7 +12,7 @@ following dependency declaration inside of your Maven project file:
     <dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs-clients</artifactId> 
-   		<version>0.13.0</version> 
+   		<version>0.13.1</version> 
    	</dependency>   
  ```
  

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/CBSChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/CBSChannel.java
@@ -6,7 +6,7 @@ package com.microsoft.azure.servicebus;
 
 import java.util.Map;
 import java.util.HashMap;
-import java.util.function.Consumer;
+import java.util.function.BiConsumer;
 
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
@@ -107,10 +107,13 @@ public class CBSChannel {
                 CBSChannel.this.sessionProvider.getSession(
                     "cbs-session",
                     null,
-                    new Consumer<ErrorCondition>() {
+                    new BiConsumer<ErrorCondition, Exception>() {
                         @Override
-                        public void accept(ErrorCondition error) {
-                            operationCallback.onError(new AmqpException(error));
+                        public void accept(ErrorCondition error, Exception exception) {
+                            if (error != null)
+                                operationCallback.onError(new AmqpException(error));
+                            else if (exception != null)
+                                operationCallback.onError(exception);
                         }
                     }));
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -52,7 +52,7 @@ public final class ClientConstants
 	public final static String DEFAULT_RETRY = "Default";
 	
 	public final static String PRODUCT_NAME = "MSJavaClient";
-	public final static String CURRENT_JAVACLIENT_VERSION = "0.13.0";
+	public final static String CURRENT_JAVACLIENT_VERSION = "0.14.0-SNAPSHOT";
 
 	public static final String PLATFORM_INFO = getPlatformInfo();
         

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientConstants.java
@@ -52,7 +52,7 @@ public final class ClientConstants
 	public final static String DEFAULT_RETRY = "Default";
 	
 	public final static String PRODUCT_NAME = "MSJavaClient";
-	public final static String CURRENT_JAVACLIENT_VERSION = "0.14.0-SNAPSHOT";
+	public final static String CURRENT_JAVACLIENT_VERSION = "0.13.1";
 
 	public static final String PLATFORM_INFO = getPlatformInfo();
         

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ISessionProvider.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ISessionProvider.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.azure.servicebus;
 
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
@@ -14,5 +15,5 @@ interface ISessionProvider
 	Session getSession(
                 final String path,
                 final Consumer<Session> onSessionOpen,
-                final Consumer<ErrorCondition> onSessionOpenError);
+                final BiConsumer<ErrorCondition, Exception> onSessionOpenError);
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -341,7 +341,8 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
 			{
 				this.setClosed();
 				ExceptionUtil.completeExceptionally(this.linkOpen.getWork(), exception, this);
-                                this.openTimer.cancel(false);
+                                if (this.openTimer != null)
+                                    this.openTimer.cancel(false);
 			}
 
 			this.lastKnownLinkError = exception;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -150,8 +150,8 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                                         }
                                         @Override
                                         public void onError(Exception error) {
-                                            if (TRACE_LOGGER.isLoggable(Level.FINE)) {
-                                                TRACE_LOGGER.log(Level.FINE,
+                                            if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
+                                                TRACE_LOGGER.log(Level.WARNING,
                                                 String.format(Locale.US,
                                                     "path[%s], linkName[%s], tokenRenewalFailure[%s]", receivePath, receiveLink.getName(), error.getMessage()));
                                             }
@@ -184,10 +184,10 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
 		return msgReceiver.createLink();
 	}
         
-        public String getReceivePath()
-	{
-		return this.receivePath;
-	}
+    public String getReceivePath()
+    {
+        return this.receivePath;
+    }
 
 	private CompletableFuture<MessageReceiver> createLink()
 	{

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -159,7 +159,11 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                                     });
                             }
                             catch(IOException|NoSuchAlgorithmException|InvalidKeyException|RuntimeException exception) {
-                                MessageReceiver.this.onError(exception);
+                                if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
+                                    TRACE_LOGGER.log(Level.WARNING,
+                                    String.format(Locale.US,
+                                        "path[%s], linkName[%s], tokenRenewalScheduleFailure[%s]", receivePath, receiveLink.getName(), error.getMessage()));
+                                }
                             }
                         }
                     },

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -162,7 +162,7 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                                 if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                     TRACE_LOGGER.log(Level.WARNING,
                                     String.format(Locale.US,
-                                        "path[%s], linkName[%s], tokenRenewalScheduleFailure[%s]", receivePath, receiveLink.getName(), error.getMessage()));
+                                        "path[%s], linkName[%s], tokenRenewalScheduleFailure[%s]", receivePath, receiveLink.getName(), exception.getMessage()));
                                 }
                             }
                         }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -175,7 +175,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                                         if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                             TRACE_LOGGER.log(Level.WARNING,
                                             String.format(Locale.US,
-                                                "path[%s], linkName[%s] - tokenRenewalScheduleFailure[%s]", sendPath, sendLink.getName(), error.getMessage()));
+                                                "path[%s], linkName[%s] - tokenRenewalScheduleFailure[%s]", sendPath, sendLink.getName(), exception.getMessage()));
                                         }
                                     }
                                 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -172,7 +172,11 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                                             });
                                     }
                                     catch(IOException|NoSuchAlgorithmException|InvalidKeyException|RuntimeException exception) {
-                                        MessageSender.this.onError(exception);
+                                        if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
+                                            TRACE_LOGGER.log(Level.WARNING,
+                                            String.format(Locale.US,
+                                                "path[%s], linkName[%s] - tokenRenewalScheduleFailure[%s]", sendPath, sendLink.getName(), error.getMessage()));
+                                        }
                                     }
                                 }
                             }, 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -164,7 +164,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                                                 @Override
                                                 public void onError(Exception error) {
                                                     if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
-                                                        TRACE_LOGGER.log(Level.FINE,
+                                                        TRACE_LOGGER.log(Level.WARNING,
                                                         String.format(Locale.US,
                                                             "path[%s], linkName[%s] - tokenRenewalFailure[%s]", sendPath, sendLink.getName(), error.getMessage()));
                                                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -403,6 +403,8 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 			{
 				this.setClosed();
 				ExceptionUtil.completeExceptionally(this.linkFirstOpen, completionException, this);
+                                if (this.openTimer != null)
+                                    this.openTimer.cancel(false);
 			}
 		}
 	}
@@ -472,7 +474,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 								public void onEvent()
 								{
 									if (!MessageSender.this.getIsClosingOrClosed()
-                                                                            && sendLink.getLocalState() == EndpointState.CLOSED || sendLink.getRemoteState() == EndpointState.CLOSED)
+                                                                            && (sendLink.getLocalState() == EndpointState.CLOSED || sendLink.getRemoteState() == EndpointState.CLOSED))
 									{
 										recreateSendLink();
 									}
@@ -772,7 +774,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 	{
                 if (this.sendLink.getLocalState() == EndpointState.CLOSED || this.sendLink.getRemoteState() == EndpointState.CLOSED)
 		{
-                        if (this.getIsClosingOrClosed())
+                        if (!this.getIsClosingOrClosed())
                             this.recreateSendLink();
                         
                         return;
@@ -854,7 +856,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 			}
 			else
 			{
-				if (weightedDelivery != null)
+				if (deliveryTag != null)
 				{
 					if (TRACE_LOGGER.isLoggable(Level.SEVERE))
 					{

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ServiceBusException.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ServiceBusException.java
@@ -34,7 +34,7 @@ public class ServiceBusException extends Exception
 		this.isTransient = isTransient;
 	}
 
-	ServiceBusException(final boolean isTransient, final String message, final Throwable cause)
+	public ServiceBusException(final boolean isTransient, final String message, final Throwable cause)
 	{
 		super(message, cause);
 		this.isTransient = isTransient;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorDispatcher.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/amqp/ReactorDispatcher.java
@@ -9,7 +9,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.Pipe;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.HashSet;
 
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Event;
@@ -72,7 +71,7 @@ public final class ReactorDispatcher
 	{
 		try
 		{
-			this.ioSignal.sink().write(ByteBuffer.allocate(1));
+			while (this.ioSignal.sink().write(ByteBuffer.allocate(1)) == 0) {}
 		}
 		catch(ClosedChannelException ignorePipeClosedDuringReactorShutdown)
 		{
@@ -116,18 +115,11 @@ public final class ReactorDispatcher
 				throw new RuntimeException(ioException);
 			}
 			
-			final HashSet<BaseHandler> completedWork = new HashSet<BaseHandler>();
 			
-			BaseHandler topWork = workQueue.poll(); 
-			while (topWork != null)
+			BaseHandler topWork; 
+			while ((topWork = workQueue.poll()) != null)
 			{
-				if (!completedWork.contains(topWork))
-				{
-					topWork.onTimerTask(null);
-					completedWork.add(topWork);
-				}
-				
-				topWork = workQueue.poll();
+                                topWork.onTimerTask(null);
 			}
 		}
 	}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
@@ -13,7 +13,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.logging.SimpleFormatter;
 
-import com.microsoft.azure.servicebus.IteratorUtil;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -27,9 +26,10 @@ import com.microsoft.azure.eventhubs.PartitionSender;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
-import com.microsoft.azure.servicebus.ConnectionStringBuilder;
-import com.microsoft.azure.servicebus.ServiceBusException;
 import com.microsoft.azure.servicebus.amqp.AmqpConstants;
+import com.microsoft.azure.servicebus.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.IteratorUtil;
+import com.microsoft.azure.servicebus.ServiceBusException;
 
 public class ReceiveParallelManualTest extends ApiTestBase
 {
@@ -110,6 +110,9 @@ public class ReceiveParallelManualTest extends ApiTestBase
         }
     }
 
+	// Run this test manually and introduce network failures to test
+	// send/receive code is resilient to n/w failures 
+	// and continues to run once the n/w is back online
 	// @Test()
 	public void testReceiverStartOfStreamFilters() throws Exception
 	{

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs.sendrecv;
+
+import java.time.Instant;
+import java.util.Iterator;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+
+import com.microsoft.azure.servicebus.IteratorUtil;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.microsoft.azure.eventhubs.EventData;
+import com.microsoft.azure.eventhubs.EventHubClient;
+import com.microsoft.azure.eventhubs.PartitionReceiver;
+import com.microsoft.azure.eventhubs.PartitionSender;
+import com.microsoft.azure.eventhubs.lib.ApiTestBase;
+import com.microsoft.azure.eventhubs.lib.TestBase;
+import com.microsoft.azure.eventhubs.lib.TestContext;
+import com.microsoft.azure.servicebus.ConnectionStringBuilder;
+import com.microsoft.azure.servicebus.ServiceBusException;
+import com.microsoft.azure.servicebus.amqp.AmqpConstants;
+
+public class ReceiveParallelManualTest extends ApiTestBase
+{
+	static final String cgName = TestContext.getConsumerGroupName();
+	static final String partitionId = "0";
+	
+	static EventHubClient ehClient;
+	
+	@BeforeClass
+	public static void initializeEventHub()  throws Exception
+	{
+		FileHandler fhc = new FileHandler("c:\\proton-sb-sendbatch-1100.log", false);
+		Logger lc1 = Logger.getLogger("servicebus.trace");
+		fhc.setFormatter(new SimpleFormatter());
+		lc1.addHandler(fhc);
+		lc1.setLevel(Level.FINE);
+
+		final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString());
+
+	}
+
+	class PRunnable implements Runnable{
+        final String sPartitionId;
+
+	    PRunnable(final String sPartitionId) {
+	        this.sPartitionId = sPartitionId;
+        }
+        @Override
+        public void run() {
+/*
+            try {
+                TestBase.pushEventsToPartition(ehClient, sPartitionId, 25000).get();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            } catch (ExecutionException e) {
+                e.printStackTrace();
+            } catch (ServiceBusException e) {
+                e.printStackTrace();
+            }*/
+
+            PartitionReceiver offsetReceiver1 = null;
+            try {
+                offsetReceiver1 = ehClient.createReceiverSync(cgName, sPartitionId, PartitionReceiver.START_OF_STREAM, false);
+            } catch (ServiceBusException e) {
+                e.printStackTrace();
+            }
+
+            Iterable<EventData> receivedEvents;
+            long totalEvents = 0L;
+            while (true) {
+                try {
+                    if ((receivedEvents = offsetReceiver1.receiveSync(10)) != null && !IteratorUtil.sizeEquals(receivedEvents, 0)) {
+
+                        long batchSize = (1 + IteratorUtil.getLast(receivedEvents.iterator()).getSystemProperties().getSequenceNumber()) -
+                                (IteratorUtil.getFirst(receivedEvents).getSystemProperties().getSequenceNumber());
+                        totalEvents += batchSize;
+                        System.out.println(String.format("[partitionId: %s] received %s events; total sofar: %s, begin: %s, end: %s",
+                                sPartitionId,
+                                batchSize,
+                                totalEvents,
+                                IteratorUtil.getLast(receivedEvents.iterator()).getSystemProperties().getSequenceNumber(),
+                                IteratorUtil.getFirst(receivedEvents).getSystemProperties().getSequenceNumber()));
+                    }
+                    else {
+                        System.out.println(String.format("received null on partition %s", sPartitionId));
+                    }
+                } catch (Exception exp) {
+                    System.out.println(exp.getMessage() + exp.toString());
+                }
+
+                try {
+                    Thread.sleep(150);
+                } catch (InterruptedException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+	// @Test()
+	public void testReceiverStartOfStreamFilters() throws Exception
+	{
+        new Thread(new PRunnable("0")).start();
+        new Thread(new PRunnable("1")).start();
+        new Thread(new PRunnable("2")).start();
+        new Thread(new PRunnable("3")).start();
+		System.in.read();
+	}
+	
+	@AfterClass()
+	public static void cleanup() throws ServiceBusException
+	{
+		if (ehClient != null)
+		{
+			ehClient.closeSync();
+		}
+	}
+}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
@@ -60,7 +60,7 @@ public class ReceiveParallelManualTest extends ApiTestBase
         }
         @Override
         public void run() {
-/*
+
             try {
                 TestBase.pushEventsToPartition(ehClient, sPartitionId, 25000).get();
             } catch (InterruptedException e) {
@@ -69,7 +69,7 @@ public class ReceiveParallelManualTest extends ApiTestBase
                 e.printStackTrace();
             } catch (ServiceBusException e) {
                 e.printStackTrace();
-            }*/
+            }
 
             PartitionReceiver offsetReceiver1 = null;
             try {

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.18.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
-		<client-current-version>0.14.0-SNAPSHOT</client-current-version>
+		<client-current-version>0.13.1</client-current-version>
 	</properties>
 	
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<proton-j-version>0.18.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
-		<client-current-version>0.13.0</client-current-version>
+		<client-current-version>0.14.0-SNAPSHOT</client-current-version>
 	</properties>
 	
 	<build>

--- a/readme.md
+++ b/readme.md
@@ -148,7 +148,7 @@ the required version of Apache Qpid Proton-J, and the crytography library BCPKIX
    	<dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs</artifactId> 
-   		<version>0.13.0</version> 
+   		<version>0.13.1</version> 
    	</dependency>   
  ```
  


### PR DESCRIPTION
* fixes stuck behaviors in Sender & Receiver
* MsgReceiver should update the pendingReceive queue before enqueing work to ReactorDispatcher
* fix receiver when prefetch queue is full
* Fix Sender & Receiver dormant links after close
* move messagesender timer out-of reactorDispatcher queue
* handle scenarios where an underlying linkOpen is pending and user invokes receiver.close()
* fix the close paths for send - for dormant links
* Move link open close timers out of ReactorDispatcher
* Clear pendingSends & Receives in case of CloseTimeout
* Don't open amqpconnection if MsgFactory is in Closed() state