### PR TITLE
Fix timeout issue in MsgFactory & thread-safety issue in MsgSender/Receiver

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -132,7 +132,7 @@ public class EventHubClient extends ClientEntity {
         final EventHubClient eventHubClient = new EventHubClient(connStr);
 
         return MessagingFactory.createFromConnectionString(connectionString.toString(), retryPolicy)
-                .thenApplyAsync(new Function<MessagingFactory, EventHubClient>() {
+                .thenApply(new Function<MessagingFactory, EventHubClient>() {
                     @Override
                     public EventHubClient apply(MessagingFactory factory) {
                         eventHubClient.underlyingFactory = factory;
@@ -205,7 +205,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("EventData cannot be empty.");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(data.toAmqpMessage());
@@ -295,7 +295,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("Empty batch of EventData cannot be sent.");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas));
@@ -371,7 +371,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("partitionKey cannot be null");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(eventData.toAmqpMessage(partitionKey));
@@ -445,7 +445,7 @@ public class EventHubClient extends ClientEntity {
                     String.format(Locale.US, "PartitionKey exceeds the maximum allowed length of partitionKey: {0}", ClientConstants.MAX_PARTITION_KEY_LENGTH));
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas, partitionKey));
@@ -1222,7 +1222,7 @@ public class EventHubClient extends ClientEntity {
         if (this.underlyingFactory != null) {
             synchronized (this.senderCreateSync) {
                 final CompletableFuture<Void> internalSenderClose = this.sender != null
-                        ? this.sender.close().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+                        ? this.sender.close().thenCompose(new Function<Void, CompletableFuture<Void>>() {
                     @Override
                     public CompletableFuture<Void> apply(Void voidArg) {
                         return EventHubClient.this.underlyingFactory.close();
@@ -1242,7 +1242,7 @@ public class EventHubClient extends ClientEntity {
             synchronized (this.senderCreateSync) {
                 if (!this.isSenderCreateStarted) {
                     this.createSender = MessageSender.create(this.underlyingFactory, StringUtil.getRandomString(), this.eventHubName)
-                            .thenAcceptAsync(new Consumer<MessageSender>() {
+                            .thenAccept(new Consumer<MessageSender>() {
                                 public void accept(MessageSender a) {
                                     EventHubClient.this.sender = a;
                                 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -124,7 +124,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
         }
 
         final PartitionReceiver receiver = new PartitionReceiver(factory, eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, dateTime, epoch, isEpochReceiver, receiverOptions);
-        return receiver.createInternalReceiver().thenApplyAsync(new Function<Void, PartitionReceiver>() {
+        return receiver.createInternalReceiver().thenApply(new Function<Void, PartitionReceiver>() {
             public PartitionReceiver apply(Void a) {
                 return receiver;
             }
@@ -136,7 +136,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
                 StringUtil.getRandomString(),
                 String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId),
                 PartitionReceiver.DEFAULT_PREFETCH_COUNT, this)
-                .thenAcceptAsync(new Consumer<MessageReceiver>() {
+                .thenAccept(new Consumer<MessageReceiver>() {
                     public void accept(MessageReceiver r) {
                         PartitionReceiver.this.internalReceiver = r;
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -37,7 +37,7 @@ public final class PartitionSender extends ClientEntity {
     static CompletableFuture<PartitionSender> Create(MessagingFactory factory, String eventHubName, String partitionId) throws ServiceBusException {
         final PartitionSender sender = new PartitionSender(factory, eventHubName, partitionId);
         return sender.createInternalSender()
-                .thenApplyAsync(new Function<Void, PartitionSender>() {
+                .thenApply(new Function<Void, PartitionSender>() {
                     public PartitionSender apply(Void a) {
                         return sender;
                     }
@@ -47,7 +47,7 @@ public final class PartitionSender extends ClientEntity {
     private CompletableFuture<Void> createInternalSender() throws ServiceBusException {
         return MessageSender.create(this.factory, StringUtil.getRandomString(),
                 String.format("%s/Partitions/%s", this.eventHubName, this.partitionId))
-                .thenAcceptAsync(new Consumer<MessageSender>() {
+                .thenAccept(new Consumer<MessageSender>() {
                     public void accept(MessageSender a) {
                         PartitionSender.this.internalSender = a;
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/CBSChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/CBSChannel.java
@@ -10,6 +10,7 @@ import java.util.function.BiConsumer;
 
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
+import org.apache.qpid.proton.engine.Session;
 import org.apache.qpid.proton.message.Message;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
@@ -100,21 +101,26 @@ public class CBSChannel {
         @Override
         public void run(IOperationResult<RequestResponseChannel, Exception> operationCallback) {
 
+            Session session = CBSChannel.this.sessionProvider.getSession(
+                    "cbs-session",
+                    null,
+                    new BiConsumer<ErrorCondition, Exception>() {
+                        @Override
+                        public void accept(ErrorCondition error, Exception exception) {
+                            if (error != null)
+                                operationCallback.onError(new AmqpException(error));
+                            else if (exception != null)
+                                operationCallback.onError(exception);
+                        }
+                    });
+
+            if (session == null)
+                return;
+
             final RequestResponseChannel requestResponseChannel = new RequestResponseChannel(
                     "cbs",
                     ClientConstants.CBS_ADDRESS,
-                    CBSChannel.this.sessionProvider.getSession(
-                            "cbs-session",
-                            null,
-                            new BiConsumer<ErrorCondition, Exception>() {
-                                @Override
-                                public void accept(ErrorCondition error, Exception exception) {
-                                    if (error != null)
-                                        operationCallback.onError(new AmqpException(error));
-                                    else if (exception != null)
-                                        operationCallback.onError(exception);
-                                }
-                            }));
+                    session);
 
             requestResponseChannel.open(
                     new IOperationResult<Void, Exception>() {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientEntity.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientEntity.java
@@ -102,9 +102,13 @@ public abstract class ClientEntity {
         }
     }
 
-    protected final void throwIfClosed(Throwable cause) {
+    protected final void throwIfClosed() {
         if (this.getIsClosingOrClosed()) {
-            throw new IllegalStateException(String.format(Locale.US, "Operation not allowed after the %s instance is Closed.", this.getClass().getName()), cause);
+            throw new IllegalStateException(String.format(Locale.US, "Operation not allowed after the %s instance is Closed.", this.getClass().getName()), this.getLastKnownError());
         }
+    }
+
+    protected Exception getLastKnownError() {
+        return null;
     }
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageReceiver.java
@@ -64,6 +64,7 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
     private final ConcurrentLinkedQueue<Message> prefetchedMessages;
     private final ReceiveWork receiveWork;
     private final CreateAndReceive createAndReceive;
+    private final Object errorCasesLock;
 
     private int prefetchCount;
     private Receiver receiveLink;
@@ -95,6 +96,7 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
         this.linkOpen = new WorkItem<>(new CompletableFuture<>(), factory.getOperationTimeout());
 
         this.pendingReceives = new ConcurrentLinkedQueue<>();
+        this.errorCasesLock = new Object();
 
         // onOperationTimeout delegate - per receive call
         this.onOperationTimedout = new Runnable() {
@@ -250,7 +252,7 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
     }
 
     public CompletableFuture<Collection<Message>> receive(final int maxMessageCount) {
-        this.throwIfClosed(this.lastKnownLinkError);
+        this.throwIfClosed();
 
         if (maxMessageCount <= 0 || maxMessageCount > this.prefetchCount) {
             throw new IllegalArgumentException(String.format(Locale.US, "parameter 'maxMessageCount' should be a positive number and should be less than prefetchCount(%s)", this.prefetchCount));
@@ -289,7 +291,9 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                     this.openTimer.cancel(false);
             }
 
-            this.lastKnownLinkError = null;
+            synchronized (this.errorCasesLock) {
+                this.lastKnownLinkError = null;
+            }
 
             this.underlyingFactory.getRetryPolicy().resetRetryCount(this.underlyingFactory.getClientId());
 
@@ -330,11 +334,6 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
         this.receiveWork.onEvent();
     }
 
-    public void onError(final ErrorCondition error) {
-        final Exception completionException = ExceptionUtil.toException(error);
-        this.onError(completionException);
-    }
-
     @Override
     public void onError(final Exception exception) {
         this.prefetchedMessages.clear();
@@ -358,7 +357,9 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
 
             this.linkClose.complete(null);
         } else {
-            this.lastKnownLinkError = exception == null ? this.lastKnownLinkError : exception;
+            synchronized (this.errorCasesLock) {
+                this.lastKnownLinkError = exception == null ? this.lastKnownLinkError : exception;
+            }
 
             final Exception completionException = exception == null
                     ? new ServiceBusException(true, "Client encountered transient error for unknown reasons, please retry the operation.") : exception;
@@ -452,7 +453,9 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
 
                 receiver.open();
 
-                MessageReceiver.this.receiveLink = receiver;
+                synchronized (MessageReceiver.this.errorCasesLock) {
+                    MessageReceiver.this.receiveLink = receiver;
+                }
             }
         };
 
@@ -460,7 +463,7 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
             @Override
             public void accept(ErrorCondition t, Exception u) {
                 if (t != null)
-                    onError(t);
+                    onError((t != null && t.getCondition() != null) ? ExceptionUtil.toException(t) : null);
                 else if (u != null)
                     onError(u);
             }
@@ -526,12 +529,19 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                 new Runnable() {
                     public void run() {
                         if (!linkOpen.getWork().isDone()) {
-                            Exception operationTimedout = new TimeoutException(
-                                    String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", MessageReceiver.this.receiveLink.getName(), MessageReceiver.this.receivePath, ZonedDateTime.now()),
-                                    MessageReceiver.this.lastKnownLinkError);
+                            final Receiver link;
+                            final Exception lastReportedLinkError;
+                            synchronized (errorCasesLock) {
+                                link = MessageReceiver.this.receiveLink;
+                                lastReportedLinkError = MessageReceiver.this.lastKnownLinkError;
+                            }
+
+                            final Exception operationTimedout = new TimeoutException(
+                                    String.format(Locale.US, "%s operation on ReceiveLink(%s) to path(%s) timed out at %s.", "Open", link.getName(), MessageReceiver.this.receivePath, ZonedDateTime.now()),
+                                    lastReportedLinkError);
                             if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                 TRACE_LOGGER.log(Level.WARNING,
-                                        String.format(Locale.US, "receiverPath[%s], linkName[%s], %s call timedout", MessageReceiver.this.receivePath, MessageReceiver.this.receiveLink.getName(), "Open"),
+                                        String.format(Locale.US, "receiverPath[%s], linkName[%s], %s call timedout", MessageReceiver.this.receivePath, link.getName(), "Open"),
                                         operationTimedout);
                             }
 
@@ -549,10 +559,15 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
                 new Runnable() {
                     public void run() {
                         if (!linkClose.isDone()) {
-                            Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", MessageReceiver.this.receiveLink.getName(), ZonedDateTime.now()));
+                            final Receiver link;
+                            synchronized (errorCasesLock) {
+                                link = MessageReceiver.this.receiveLink;
+                            }
+
+                            final Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", link.getName(), ZonedDateTime.now()));
                             if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                 TRACE_LOGGER.log(Level.WARNING,
-                                        String.format(Locale.US, "receiverPath[%s], linkName[%s], %s call timedout", MessageReceiver.this.receivePath, MessageReceiver.this.receiveLink.getName(), "Close"),
+                                        String.format(Locale.US, "receiverPath[%s], linkName[%s], %s call timedout", MessageReceiver.this.receivePath, link.getName(), "Close"),
                                         operationTimedout);
                             }
 
@@ -567,25 +582,27 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
 
     @Override
     public void onClose(ErrorCondition condition) {
-        if (condition == null || condition.getCondition() == null) {
-            this.onError((Exception) null);
-        } else {
-            this.onError(condition);
-        }
+        final Exception completionException = (condition != null && condition.getCondition() != null) ? ExceptionUtil.toException(condition) : null;
+        this.onError(completionException);
     }
 
     @Override
     public ErrorContext getContext() {
-        final boolean isLinkOpened = this.linkOpen != null && this.linkOpen.getWork().isDone();
-        final String referenceId = this.receiveLink != null && this.receiveLink.getRemoteProperties() != null && this.receiveLink.getRemoteProperties().containsKey(ClientConstants.TRACKING_ID_PROPERTY)
-                ? this.receiveLink.getRemoteProperties().get(ClientConstants.TRACKING_ID_PROPERTY).toString()
-                : ((this.receiveLink != null) ? this.receiveLink.getName() : null);
+        final Receiver link;
+        synchronized (this.errorCasesLock) {
+            link = this.receiveLink;
+        }
 
-        ReceiverContext errorContext = new ReceiverContext(this.underlyingFactory != null ? this.underlyingFactory.getHostName() : null,
+        final boolean isLinkOpened = this.linkOpen != null && this.linkOpen.getWork().isDone();
+        final String referenceId = link != null && link.getRemoteProperties() != null && link.getRemoteProperties().containsKey(ClientConstants.TRACKING_ID_PROPERTY)
+                ? link.getRemoteProperties().get(ClientConstants.TRACKING_ID_PROPERTY).toString()
+                : ((link != null) ? link.getName() : null);
+
+        final ReceiverContext errorContext = new ReceiverContext(this.underlyingFactory != null ? this.underlyingFactory.getHostName() : null,
                 this.receivePath,
                 referenceId,
                 isLinkOpened ? this.prefetchCount : null,
-                isLinkOpened && this.receiveLink != null ? this.receiveLink.getCredit() : null,
+                isLinkOpened && link != null ? link.getCredit() : null,
                 isLinkOpened && this.prefetchedMessages != null ? this.prefetchedMessages.size() : null);
 
         return errorContext;
@@ -626,6 +643,13 @@ public final class MessageReceiver extends ClientEntity implements IAmqpReceiver
         }
 
         return this.linkClose;
+    }
+
+    @Override
+    protected Exception getLastKnownError() {
+        synchronized (this.errorCasesLock) {
+            return this.lastKnownLinkError;
+        }
     }
 
     private final class ReceiveWork extends DispatchHandler {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/MessageSender.java
@@ -72,6 +72,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
     private final DispatchHandler sendWork;
     private final ActiveClientTokenManager activeClientTokenManager;
     private final String tokenAudience;
+    private final Object errorConditionLock;
 
     private Sender sendLink;
     private CompletableFuture<MessageSender> linkFirstOpen;
@@ -116,6 +117,8 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
         this.lastKnownErrorReportedAt = Instant.EPOCH;
 
         this.retryPolicy = factory.getRetryPolicy();
+
+        this.errorConditionLock = new Object();
 
         this.pendingSendLock = new Object();
         this.pendingSendsData = new ConcurrentHashMap<>();
@@ -189,7 +192,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
             final TimeoutTracker tracker,
             final Exception lastKnownError,
             final ScheduledFuture<?> timeoutTask) {
-        this.throwIfClosed(this.lastKnownLinkError);
+        this.throwIfClosed();
 
         final boolean isRetrySend = (onSend != null);
 
@@ -381,8 +384,10 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 
             return;
         } else {
-            this.lastKnownLinkError = completionException == null ? this.lastKnownLinkError : completionException;
-            this.lastKnownErrorReportedAt = Instant.now();
+            synchronized (this.errorConditionLock) {
+                this.lastKnownLinkError = completionException == null ? this.lastKnownLinkError : completionException;
+                this.lastKnownErrorReportedAt = Instant.now();
+            }
 
             final Exception finalCompletionException = completionException == null
                     ? new ServiceBusException(true, "Client encountered transient error for unknown reasons, please retry the operation.") : completionException;
@@ -534,7 +539,9 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                 MessageSender.this.underlyingFactory.registerForConnectionError(sender);
                 sender.open();
 
-                MessageSender.this.sendLink = sender;
+                synchronized (MessageSender.this.errorConditionLock) {
+                    MessageSender.this.sendLink = sender;
+                }
             }
         };
 
@@ -542,7 +549,7 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
             @Override
             public void accept(ErrorCondition t, Exception u) {
                 if (t != null)
-                    MessageSender.this.onClose(t);
+                    MessageSender.this.onError((t != null && t.getCondition() != null) ? ExceptionUtil.toException(t) : null);
                 else if (u != null)
                     MessageSender.this.onError(u);
             }
@@ -584,9 +591,18 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                 new Runnable() {
                     public void run() {
                         if (!MessageSender.this.linkFirstOpen.isDone()) {
-                            Exception operationTimedout = new TimeoutException(
-                                    String.format(Locale.US, "Open operation on SendLink(%s) on Entity(%s) timed out at %s.", MessageSender.this.sendLink.getName(), MessageSender.this.getSendPath(), ZonedDateTime.now().toString()),
-                                    MessageSender.this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS)) ? MessageSender.this.lastKnownLinkError : null);
+                            final Exception lastReportedError;
+                            final Instant lastErrorReportedAt;
+                            final Sender link;
+                            synchronized (MessageSender.this.errorConditionLock) {
+                                lastReportedError = MessageSender.this.lastKnownLinkError;
+                                lastErrorReportedAt = MessageSender.this.lastKnownErrorReportedAt;
+                                link = MessageSender.this.sendLink;
+                            }
+
+                            final Exception operationTimedout = new TimeoutException(
+                                    String.format(Locale.US, "Open operation on SendLink(%s) on Entity(%s) timed out at %s.", link.getName(), MessageSender.this.getSendPath(), ZonedDateTime.now().toString()),
+                                    lastErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS)) ? lastReportedError : null);
 
                             if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                 TRACE_LOGGER.log(Level.WARNING,
@@ -604,16 +620,21 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
 
     @Override
     public ErrorContext getContext() {
-        final boolean isLinkOpened = this.linkFirstOpen != null && this.linkFirstOpen.isDone();
-        final String referenceId = this.sendLink != null && this.sendLink.getRemoteProperties() != null && this.sendLink.getRemoteProperties().containsKey(ClientConstants.TRACKING_ID_PROPERTY)
-                ? this.sendLink.getRemoteProperties().get(ClientConstants.TRACKING_ID_PROPERTY).toString()
-                : ((this.sendLink != null) ? this.sendLink.getName() : null);
+        final Sender link;
+        synchronized (this.errorConditionLock) {
+            link = this.sendLink;
+        }
 
-        SenderContext errorContext = new SenderContext(
+        final boolean isLinkOpened = this.linkFirstOpen != null && this.linkFirstOpen.isDone();
+        final String referenceId = link != null && link.getRemoteProperties() != null && link.getRemoteProperties().containsKey(ClientConstants.TRACKING_ID_PROPERTY)
+                ? link.getRemoteProperties().get(ClientConstants.TRACKING_ID_PROPERTY).toString()
+                : ((link != null) ? link.getName() : null);
+
+        final SenderContext errorContext = new SenderContext(
                 this.underlyingFactory != null ? this.underlyingFactory.getHostName() : null,
                 this.sendPath,
                 referenceId,
-                isLinkOpened && this.sendLink != null ? this.sendLink.getCredit() : null);
+                isLinkOpened && link != null ? link.getCredit() : null);
         return errorContext;
     }
 
@@ -722,18 +743,28 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
         }
     }
 
-    private void throwSenderTimeout(CompletableFuture<Void> pendingSendWork, Exception lastKnownException) {
+    private void throwSenderTimeout(final CompletableFuture<Void> pendingSendWork, final Exception lastKnownException) {
+
         Exception cause = lastKnownException;
-        if (lastKnownException == null && this.lastKnownLinkError != null) {
-            boolean isServerBusy = ((this.lastKnownLinkError instanceof ServerBusyException)
-                    && (this.lastKnownErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS))));
-            cause = isServerBusy || (this.lastKnownErrorReportedAt.isAfter(Instant.now().minusMillis(this.operationTimeout.toMillis())))
-                    ? this.lastKnownLinkError
-                    : null;
+        if (lastKnownException == null) {
+            final Exception lastReportedLinkLevelError;
+            final Instant lastLinkErrorReportedAt;
+            synchronized (this.errorConditionLock) {
+                lastReportedLinkLevelError = this.lastKnownLinkError;
+                lastLinkErrorReportedAt = this.lastKnownErrorReportedAt;
+            }
+
+            if (lastReportedLinkLevelError != null) {
+                boolean isServerBusy = ((lastReportedLinkLevelError instanceof ServerBusyException)
+                        && (lastLinkErrorReportedAt.isAfter(Instant.now().minusSeconds(ClientConstants.SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS))));
+                cause = isServerBusy || (lastLinkErrorReportedAt.isAfter(Instant.now().minusMillis(this.operationTimeout.toMillis())))
+                        ? lastReportedLinkLevelError
+                        : null;
+            }
         }
 
-        boolean isClientSideTimeout = (cause == null || !(cause instanceof ServiceBusException));
-        ServiceBusException exception = isClientSideTimeout
+        final boolean isClientSideTimeout = (cause == null || !(cause instanceof ServiceBusException));
+        final ServiceBusException exception = isClientSideTimeout
                 ? new TimeoutException(String.format(Locale.US, "%s %s %s.", MessageSender.SEND_TIMED_OUT, " at ", ZonedDateTime.now(), cause))
                 : (ServiceBusException) cause;
 
@@ -746,10 +777,15 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
                 new Runnable() {
                     public void run() {
                         if (!linkClose.isDone()) {
-                            Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", MessageSender.this.sendLink.getName(), ZonedDateTime.now()));
+                            final Sender link;
+                            synchronized (MessageSender.this.errorConditionLock) {
+                                link = MessageSender.this.sendLink;
+                            }
+
+                            final Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", link.getName(), ZonedDateTime.now()));
                             if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
                                 TRACE_LOGGER.log(Level.WARNING,
-                                        String.format(Locale.US, "message recever(linkName: %s, path: %s) %s call timedout", MessageSender.this.sendLink.getName(), MessageSender.this.sendPath, "Close"),
+                                        String.format(Locale.US, "message recever(linkName: %s, path: %s) %s call timedout", link.getName(), MessageSender.this.sendPath, "Close"),
                                         operationTimedout);
                             }
 
@@ -788,6 +824,13 @@ public class MessageSender extends ClientEntity implements IAmqpSender, IErrorCo
         }
 
         return this.linkClose;
+    }
+
+    @Override
+    protected Exception getLastKnownError() {
+        synchronized (this.errorConditionLock) {
+            return this.lastKnownLinkError;
+        }
     }
 
     private static class WeightedDeliveryTag {


### PR DESCRIPTION
* fix connection open/close timeout paths
* use non ForkJoinPool variants while composing completable futures (https://github.com/Azure/azure-event-hubs-java/issues/4)
* fix thread-safety in MessageSender & MessageReceiver in error cases(https://github.com/Azure/azure-event-hubs-java/issues/4)