### PR TITLE
Fix timeout issue in MsgFactory & thread-safety issue in MsgSender/Recvr

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -132,7 +132,7 @@ public class EventHubClient extends ClientEntity {
         final EventHubClient eventHubClient = new EventHubClient(connStr);
 
         return MessagingFactory.createFromConnectionString(connectionString.toString(), retryPolicy)
-                .thenApplyAsync(new Function<MessagingFactory, EventHubClient>() {
+                .thenApply(new Function<MessagingFactory, EventHubClient>() {
                     @Override
                     public EventHubClient apply(MessagingFactory factory) {
                         eventHubClient.underlyingFactory = factory;
@@ -205,7 +205,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("EventData cannot be empty.");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(data.toAmqpMessage());
@@ -295,7 +295,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("Empty batch of EventData cannot be sent.");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas));
@@ -371,7 +371,7 @@ public class EventHubClient extends ClientEntity {
             throw new IllegalArgumentException("partitionKey cannot be null");
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(eventData.toAmqpMessage(partitionKey));
@@ -445,7 +445,7 @@ public class EventHubClient extends ClientEntity {
                     String.format(Locale.US, "PartitionKey exceeds the maximum allowed length of partitionKey: {0}", ClientConstants.MAX_PARTITION_KEY_LENGTH));
         }
 
-        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas, partitionKey));
@@ -1222,7 +1222,7 @@ public class EventHubClient extends ClientEntity {
         if (this.underlyingFactory != null) {
             synchronized (this.senderCreateSync) {
                 final CompletableFuture<Void> internalSenderClose = this.sender != null
-                        ? this.sender.close().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
+                        ? this.sender.close().thenCompose(new Function<Void, CompletableFuture<Void>>() {
                     @Override
                     public CompletableFuture<Void> apply(Void voidArg) {
                         return EventHubClient.this.underlyingFactory.close();
@@ -1242,7 +1242,7 @@ public class EventHubClient extends ClientEntity {
             synchronized (this.senderCreateSync) {
                 if (!this.isSenderCreateStarted) {
                     this.createSender = MessageSender.create(this.underlyingFactory, StringUtil.getRandomString(), this.eventHubName)
-                            .thenAcceptAsync(new Consumer<MessageSender>() {
+                            .thenAccept(new Consumer<MessageSender>() {
                                 public void accept(MessageSender a) {
                                     EventHubClient.this.sender = a;
                                 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -124,7 +124,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
         }
 
         final PartitionReceiver receiver = new PartitionReceiver(factory, eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, dateTime, epoch, isEpochReceiver, receiverOptions);
-        return receiver.createInternalReceiver().thenApplyAsync(new Function<Void, PartitionReceiver>() {
+        return receiver.createInternalReceiver().thenApply(new Function<Void, PartitionReceiver>() {
             public PartitionReceiver apply(Void a) {
                 return receiver;
             }
@@ -136,7 +136,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
                 StringUtil.getRandomString(),
                 String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId),
                 PartitionReceiver.DEFAULT_PREFETCH_COUNT, this)
-                .thenAcceptAsync(new Consumer<MessageReceiver>() {
+                .thenAccept(new Consumer<MessageReceiver>() {
                     public void accept(MessageReceiver r) {
                         PartitionReceiver.this.internalReceiver = r;
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -37,7 +37,7 @@ public final class PartitionSender extends ClientEntity {
     static CompletableFuture<PartitionSender> Create(MessagingFactory factory, String eventHubName, String partitionId) throws ServiceBusException {
         final PartitionSender sender = new PartitionSender(factory, eventHubName, partitionId);
         return sender.createInternalSender()
-                .thenApplyAsync(new Function<Void, PartitionSender>() {
+                .thenApply(new Function<Void, PartitionSender>() {
                     public PartitionSender apply(Void a) {
                         return sender;
                     }
@@ -47,7 +47,7 @@ public final class PartitionSender extends ClientEntity {
     private CompletableFuture<Void> createInternalSender() throws ServiceBusException {
         return MessageSender.create(this.factory, StringUtil.getRandomString(),
                 String.format("%s/Partitions/%s", this.eventHubName, this.partitionId))
-                .thenAcceptAsync(new Consumer<MessageSender>() {
+                .thenAccept(new Consumer<MessageSender>() {
                     public void accept(MessageSender a) {
                         PartitionSender.this.internalSender = a;
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientEntity.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/servicebus/ClientEntity.java
@@ -102,9 +102,13 @@ public abstract class ClientEntity {
         }
     }
 
-    protected final void throwIfClosed(Throwable cause) {
+    protected final void throwIfClosed() {
         if (this.getIsClosingOrClosed()) {
-            throw new IllegalStateException(String.format(Locale.US, "Operation not allowed after the %s instance is Closed.", this.getClass().getName()), cause);
+            throw new IllegalStateException(String.format(Locale.US, "Operation not allowed after the %s instance is Closed.", this.getClass().getName()), this.getLastKnownError());
         }
+    }
+
+    protected Exception getLastKnownError() {
+        return null;
     }
 }


### PR DESCRIPTION
* fix connection open/close timeout paths
* use non ForkJoinPool variants while composing completable futures (https://github.com/Azure/azure-event-hubs-java/issues/4)
* fix thread-safety in MessageSender & MessageReceiver in error cases(https://github.com/Azure/azure-event-hubs-java/issues/4)