### PR TITLE
Handle StorageExceptions from AzureBlobLease.isExpired

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -19,6 +19,7 @@ import com.microsoft.azure.eventhubs.EventHubRuntimeInformation;
 import com.microsoft.azure.servicebus.IllegalEntityException;
 import com.microsoft.azure.servicebus.ServiceBusException;
 import com.microsoft.azure.servicebus.TimeoutException;
+import com.microsoft.azure.storage.StorageException;
 
 class PartitionManager
 {
@@ -325,7 +326,11 @@ class PartitionManager
                     	leasesOwnedByOthers.add(possibleLease);
                     }
             	}
-            	catch (ExecutionException e)
+        		// Most exceptions will arrive packaged as ExecutionException because they occur during a short-lived thread
+        		// down in AzureStorageCheckpointLeastManager. However, AzureBlobLease.isExpired calls Storage directly and
+        		// therefore can throw a plain StorageException. Handling is the same for all: log, notify, and move on to the
+            	// next partition.
+            	catch (ExecutionException|StorageException e)
             	{
             		this.host.logWithHost(Level.WARNING, "Failure getting/acquiring/renewing lease, skipping", e);
             		this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.CHECKING_LEASES,

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -333,7 +333,12 @@ class PartitionManager
             	catch (ExecutionException|StorageException e)
             	{
             		this.host.logWithHost(Level.WARNING, "Failure getting/acquiring/renewing lease, skipping", e);
-            		this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.CHECKING_LEASES,
+            		Exception notifyWith = e;
+            		if ((e instanceof ExecutionException) && (e.getCause() != null) && (e.getCause() instanceof Exception))
+            		{
+            			notifyWith = (Exception)e.getCause();
+            		}
+            		this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), notifyWith, EventProcessorHostActionStrings.CHECKING_LEASES,
             				((possibleLease != null) ? possibleLease.getPartitionId() : ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION));
             	}
             }


### PR DESCRIPTION
## Description
Found during a stress run that was experiencing Storage errors: PartitionManager.runLoop was seeing StorageExceptions that it was not prepared to catch and they was killing the host instance. Most exceptions, including StorageExceptions, arrive at runLoop packaged as ExecutionExceptions because they occur in another thread and rethrow as ExecutionExceptions when get is called on a Future. However, AzureBlobLease.isExpired, which is called at the top of the inner loop in runLoop, calls Storage directly and hence can throw a plain StorageException. The handling required is the same (log, notify, and move on), so fixed by adding StorageException to the catch.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.