### PR TITLE
Handle receiver open failures properly.

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -70,6 +70,25 @@ abstract class PartitionPump
         	specializedStartPump();
         }
         
+        if (this.pumpStatus != PartitionPumpStatus.PP_RUNNING)
+        {
+            // Something went wrong in specialized startup, so clean up the processor.
+            this.pumpStatus = PartitionPumpStatus.PP_CLOSING;
+            try
+            {
+                this.processor.onClose(this.partitionContext, CloseReason.Shutdown);
+            }
+            catch (Exception e)
+            {
+                // If the processor fails on close, just log and notify.
+                this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, "Failed " + EventProcessorHostActionStrings.CLOSING_EVENT_PROCESSOR, e);
+                this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.CLOSING_EVENT_PROCESSOR,
+                   this.lease.getPartitionId());
+            }
+            this.processor = null;
+            this.pumpStatus = PartitionPumpStatus.PP_CLOSED;
+        }
+
         return null;
     }
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.util.ArrayList;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -58,9 +59,23 @@ class Pump
     private void createNewPump(String partitionId, Lease lease) throws Exception
     {
 		PartitionPump newPartitionPump = new EventHubPartitionPump(this.host, this, lease);
-		EventProcessorHost.getExecutorService().submit(() -> newPartitionPump.startPump());
-        this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
-		this.host.logWithHostAndPartition(Level.FINE, partitionId, "created new pump");
+		EventProcessorHost.getExecutorService().submit(new Callable<Void>()
+			{
+				@Override
+				public Void call() throws Exception
+				{
+					// Do this whole section as a callable so it runs on a separate thread and doesn't hold up the main loop.
+					// The problem is we have to wait for startPump to return in order to know whether to add the pump
+					// to pumpStates.
+					newPartitionPump.startPump();
+					if (newPartitionPump.getPumpStatus() == PartitionPumpStatus.PP_RUNNING)
+					{
+						Pump.this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
+						Pump.this.host.logWithHostAndPartition(Level.FINE, partitionId, "created new pump");
+					}
+					return null;
+				}
+			});
     }
     
     public Future<?> removePump(String partitionId, final CloseReason reason)


### PR DESCRIPTION
## Description
If a ReceiverDisconnectedException was thrown while opening a receiver, the cleanup was only partial. There were two problems: (1) IEventProcessor.onClose was never called, so the processor instance did not know to clean up, and (2) Pump.createNewPump did not check for pump start failure and hence put a zombie pump into the pumpStates map.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.