### PR TITLE
Cleanup on receiver disconnect during open and other small improvements

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -25,7 +25,8 @@ public final class EventProcessorHost
 
     private ICheckpointManager checkpointManager;
     private ILeaseManager leaseManager;
-    private boolean initializeLeaseManager = false; 
+    private boolean initializeLeaseManager = false;
+    private boolean unregistered = false;
     private PartitionManager partitionManager;
     private IEventProcessorFactory<?> processorFactory = null;
     private EventProcessorOptions processorOptions;
@@ -509,6 +510,10 @@ public final class EventProcessorHost
      */
     public Future<?> registerEventProcessorFactory(IEventProcessorFactory<?> factory, EventProcessorOptions processorOptions) throws Exception
     {
+        if (this.unregistered)
+        {
+            throw new IllegalStateException("Register cannot be called on an EventProcessorHost after unregister. Please create a new EventProcessorHost instance.");
+        }
     	if (this.processorFactory != null)
     	{
     		throw new IllegalStateException("Register has already been called on this EventProcessorHost");
@@ -548,6 +553,7 @@ public final class EventProcessorHost
     public void unregisterEventProcessor() throws InterruptedException, ExecutionException
     {
     	logWithHost(Level.FINE, "Stopping event processing");
+        this.unregistered = true;
     	
     	if (this.partitionManager != null)
     	{

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -70,6 +70,25 @@ abstract class PartitionPump
         	specializedStartPump();
         }
         
+        if (this.pumpStatus != PartitionPumpStatus.PP_RUNNING)
+        {
+            // Something went wrong in specialized startup, so clean up the processor.
+            this.pumpStatus = PartitionPumpStatus.PP_CLOSING;
+            try
+            {
+                this.processor.onClose(this.partitionContext, CloseReason.Shutdown);
+            }
+            catch (Exception e)
+            {
+                // If the processor fails on close, just log and notify.
+                this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, "Failed " + EventProcessorHostActionStrings.CLOSING_EVENT_PROCESSOR, e);
+                this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.CLOSING_EVENT_PROCESSOR,
+                   this.lease.getPartitionId());
+            }
+            this.processor = null;
+            this.pumpStatus = PartitionPumpStatus.PP_CLOSED;
+        }
+
         return null;
     }
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -72,7 +72,7 @@ abstract class PartitionPump
         
         if (this.pumpStatus != PartitionPumpStatus.PP_RUNNING)
         {
-            // Something went wrong in specialized startup, so clean up the processor.
+            // There was an error in specialized startup, so clean up the processor.
             this.pumpStatus = PartitionPumpStatus.PP_CLOSING;
             try
             {

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -64,9 +64,8 @@ class Pump
 				@Override
 				public Void call() throws Exception
 				{
-					// Do this whole section as a callable so it runs on a separate thread and doesn't hold up the main loop.
-					// The problem is we have to wait for startPump to return in order to know whether to add the pump
-					// to pumpStates.
+					// Do this whole section as a callable so it runs on a separate thread and doesn't hold up the main loop
+					// while we wait for startPump to return in order to know whether to add the pump to pumpStates.
 					newPartitionPump.startPump();
 					if (newPartitionPump.getPumpStatus() == PartitionPumpStatus.PP_RUNNING)
 					{

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -6,6 +6,7 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.util.ArrayList;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -58,9 +59,23 @@ class Pump
     private void createNewPump(String partitionId, Lease lease) throws Exception
     {
 		PartitionPump newPartitionPump = new EventHubPartitionPump(this.host, this, lease);
-		EventProcessorHost.getExecutorService().submit(() -> newPartitionPump.startPump());
-        this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
-		this.host.logWithHostAndPartition(Level.FINE, partitionId, "created new pump");
+		EventProcessorHost.getExecutorService().submit(new Callable<Void>()
+			{
+				@Override
+				public Void call() throws Exception
+				{
+					// Do this whole section as a callable so it runs on a separate thread and doesn't hold up the main loop.
+					// The problem is we have to wait for startPump to return in order to know whether to add the pump
+					// to pumpStates.
+					newPartitionPump.startPump();
+					if (newPartitionPump.getPumpStatus() == PartitionPumpStatus.PP_RUNNING)
+					{
+						Pump.this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
+						Pump.this.host.logWithHostAndPartition(Level.FINE, partitionId, "created new pump");
+					}
+					return null;
+				}
+			});
     }
     
     public Future<?> removePump(String partitionId, final CloseReason reason)

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/EPHConstructorTests.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/EPHConstructorTests.java
@@ -9,7 +9,7 @@ public class EPHConstructorTests extends TestBase
 	public void conflictingEventHubPathsTest() throws Exception
 	{
 		PerTestSettings settings = new PerTestSettings("ConflictingEventHubPaths");
-		settings.inEntityDoesNotExist = true;
+		settings.inEventHubDoesNotExist = true;
 		settings.inoutEPHConstructorArgs.setEHPath("thisisdifferentfromtheconnectionstring", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE);
 		try
 		{
@@ -37,7 +37,7 @@ public class EPHConstructorTests extends TestBase
 	public void missingEventHubPathTest() throws Exception
 	{
 		PerTestSettings settings = new PerTestSettings("MissingEventHubPath");
-		settings.inEntityDoesNotExist = true;
+		settings.inEventHubDoesNotExist = true;
 		settings.inoutEPHConstructorArgs.setEHPath("", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE_AND_REPLACE);
 		try
 		{

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PerTestSettings.java
@@ -9,7 +9,7 @@ public class PerTestSettings
 	private String inTestName;
 	EventProcessorOptions inOptions; // can be null
 	PrefabEventProcessor.CheckpointChoices inDoCheckpoint;
-	boolean inEntityDoesNotExist; // Prevents test code from doing certain checks that would fail on nonexistence before reaching product code.
+	boolean inEventHubDoesNotExist; // Prevents test code from doing certain checks that would fail on nonexistence before reaching product code.
 	boolean inTelltaleOnTimeout; // Generates an empty telltale string, which causes PrefabEventProcessor to trigger telltale on timeout.
 	boolean inHasSenders;
 	
@@ -18,7 +18,7 @@ public class PerTestSettings
 		this.inTestName = testName;
 		this.inOptions = EventProcessorOptions.getDefaultOptions();
 		this.inDoCheckpoint = PrefabEventProcessor.CheckpointChoices.CKP_NONE;
-		this.inEntityDoesNotExist = false;
+		this.inEventHubDoesNotExist = false;
 		this.inTelltaleOnTimeout = false;
 		this.inHasSenders = true;
 		

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
@@ -34,11 +34,13 @@ public class PrefabEventProcessor implements IEventProcessor
 	@Override
 	public void onOpen(PartitionContext context) throws Exception
 	{
+		TestUtilities.log(context.getOwner() + " opening " + context.getPartitionId());
 	}
 
 	@Override
 	public void onClose(PartitionContext context, CloseReason reason) throws Exception
 	{
+		TestUtilities.log(context.getOwner() + " closing " + context.getPartitionId());
 	}
 
 	@Override
@@ -59,7 +61,7 @@ public class PrefabEventProcessor implements IEventProcessor
 			}
 			if (this.logEveryMessage)
 			{
-				TestUtilities.log("P" + context.getPartitionId() + " " + new String(event.getBody()) + " @ " + event.getSystemProperties().getOffset() + "\n");
+				//TestUtilities.log("P" + context.getPartitionId() + " " + new String(event.getBody()) + " @ " + event.getSystemProperties().getOffset() + "\n");
 			}
 			if (Arrays.equals(event.getBody(), this.telltaleBytes))
 			{

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
@@ -13,7 +13,7 @@ public class SadPathTests extends TestBase
 	public void noSuchEventHubTest() throws Exception
 	{
 		PerTestSettings settings = new PerTestSettings("NoSuchEventHub");
-		settings.inEntityDoesNotExist = true;
+		settings.inEventHubDoesNotExist = true;
 		settings.inoutEPHConstructorArgs.setEHPath("thereisnoeventhubwiththisname", PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE_AND_REPLACE);
 		try
 		{
@@ -42,7 +42,6 @@ public class SadPathTests extends TestBase
 	public void noSuchConsumerGroupTest() throws Exception
 	{
 		PerTestSettings settings = new PerTestSettings("NoSuchConsumerGroup");
-		settings.inEntityDoesNotExist = true;
 		settings.inoutEPHConstructorArgs.setConsumerGroupName("thereisnoconsumergroupwiththisname");
 		try
 		{
@@ -52,16 +51,9 @@ public class SadPathTests extends TestBase
 		catch (ExecutionException e)
 		{
 			Throwable inner = e.getCause();
-			if ((inner != null) && (inner instanceof EPHConfigurationException))
+			if ((inner != null) && (inner instanceof IllegalEntityException))
 			{
-				if ((inner.getMessage() != null) && (inner.getMessage().compareTo("Consumer group does not exist") == 0))
-				{
-					TestUtilities.log("Got expected exception\n");
-				}
-				else
-				{
-					throw e;
-				}
+				TestUtilities.log("Got expected IllegalEntityException\n");
 			}
 			else
 			{
@@ -83,11 +75,51 @@ public class SadPathTests extends TestBase
 		try
 		{
 			settings.outHost.registerEventProcessorFactory(settings.outProcessorFactory, settings.inOptions).get();
+			Thread.sleep(10000);
 			fail("No exception occurred");
 		}
 		catch (IllegalStateException e)
 		{
-			TestUtilities.log("Got expected exception\n");
+			if ((e.getMessage() != null) && (e.getMessage().compareTo("Register has already been called on this EventProcessorHost") == 0))
+			{
+				TestUtilities.log("Got expected exception\n");
+			}
+			else
+			{
+				fail("Got IllegalStateException but text is wrong");
+			}
+		}
+		finally
+		{
+			testFinish(settings, NO_CHECKS);
+		}
+	}
+	
+	@Test
+	public void reregisterFailsTest() throws Exception
+	{
+		PerTestSettings settings = new PerTestSettings("ReregisterFails");
+		settings = testSetup(settings);
+		
+		try
+		{
+			Thread.sleep(15000);
+			settings.outHost.unregisterEventProcessor();
+
+			settings.outHost.registerEventProcessorFactory(settings.outProcessorFactory, settings.inOptions).get();
+			Thread.sleep(10000);
+			fail("No exception occurred");
+		}
+		catch (IllegalStateException e)
+		{
+			if ((e.getMessage() != null) && (e.getMessage().compareTo("Register cannot be called on an EventProcessorHost after unregister. Please create a new EventProcessorHost instance.") == 0))
+			{
+				TestUtilities.log("Got expected exception\n");
+			}
+			else
+			{
+				fail("Got IllegalStateException but text is wrong");
+			}
 		}
 		finally
 		{

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/SadPathTests.java
@@ -126,4 +126,35 @@ public class SadPathTests extends TestBase
 			testFinish(settings, NO_CHECKS);
 		}
 	}
+
+	@Test
+	public void badEventHubNameTest() throws Exception
+	{
+        // This case requires an eventhub with a bad name (not legal as storage container name).
+        // Within EPH the validation of the name occurs after other operations that fail if the eventhub
+        // doesn't exist, so this case can't use arbitrary bad names.
+        PerTestSettings settings = new PerTestSettings("BadEventHubName");
+        try
+        {
+            settings.inoutEPHConstructorArgs.setStorageContainerName(null); // otherwise test framework creates unique storage container name
+            settings = testSetup(settings);
+            fail("No exception occurred");
+        }
+        catch (IllegalArgumentException e)
+        {
+            String message = e.getMessage();
+            if ((message != null) && message.startsWith("EventHub names must conform to the following rules"))
+            {
+                TestUtilities.log("Got expected IllegalArgumentException\n");
+            }
+            else
+            {
+                throw e;
+            }
+        }
+        finally
+        {
+            testFinish(settings, NO_CHECKS);
+        }
+    }
 }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -25,11 +25,11 @@ public class TestBase
 		settings.outUtils = new RealEventHubUtilities();
 		if (settings.inHasSenders)
 		{
-			settings.outPartitionIds = settings.outUtils.setup(settings.inEntityDoesNotExist ? 8 : RealEventHubUtilities.QUERY_ENTITY_FOR_PARTITIONS);
+			settings.outPartitionIds = settings.outUtils.setup(settings.inEventHubDoesNotExist ? 8 : RealEventHubUtilities.QUERY_ENTITY_FOR_PARTITIONS);
 		}
 		else
 		{
-			settings.outPartitionIds = settings.outUtils.setupWithoutSenders(settings.inEntityDoesNotExist ? 8 : RealEventHubUtilities.QUERY_ENTITY_FOR_PARTITIONS);
+			settings.outPartitionIds = settings.outUtils.setupWithoutSenders(settings.inEventHubDoesNotExist ? 8 : RealEventHubUtilities.QUERY_ENTITY_FOR_PARTITIONS);
 		}
 		ConnectionStringBuilder environmentCSB = settings.outUtils.getConnectionString();
 

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -89,7 +89,11 @@ public class TestBase
 			String effectiveStorageContainerName = settings.getTestName().toLowerCase() + "-" + EventProcessorHost.safeCreateUUID();
 			if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.STORAGE_CONTAINER_OVERRIDE))
 			{
-				effectiveStorageContainerName = settings.inoutEPHConstructorArgs.getStorageContainerName().toLowerCase();
+				effectiveStorageContainerName = settings.inoutEPHConstructorArgs.getStorageContainerName();
+				if (effectiveStorageContainerName != null)
+				{
+					effectiveStorageContainerName = effectiveStorageContainerName.toLowerCase();
+				}
 			}
 			else
 			{


### PR DESCRIPTION
## Description

Do complete cleanup on receiver disconnect thrown during receiver open.
Provide good error if event hub name is not valid storage container name.
Provide good error on register after unregister.
Additional test cases.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.