### PR TITLE
Fix deadlock in cleanup after ReceiverDisconnectedException

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -192,7 +192,8 @@ abstract class PartitionPump
         }
 	}
     
-    protected void onError(Throwable error)
+    // Returns Void so it can be called from a lambda.
+    protected Void onError(Throwable error)
     {
     	// How this method gets called:
     	// 1) JavaClient calls an error handler installed by EventHubPartitionPump.
@@ -209,5 +210,7 @@ abstract class PartitionPump
     	// Notify upstream that this pump is dead so that cleanup will occur.
     	// Failing to do so results in reactor threads leaking.
     	this.pump.onPumpError(this.partitionContext.getPartitionId());
+
+        return null;
     }
 }


### PR DESCRIPTION
## Description

When a ReceiverDisconnectedException occurred due to a receiver with a higher epoch being created in the processor partition stealing, the previously owning host would try to clean up. It did so on the client's receive pump thread, meaning the receive pump would not exit and complete a CompletableFuture ("A") until the cleanup was finished. As part of the cleanup, it spawned another thread to do client artifact cleanup, and waited for that thread to finish. Unfortunately the client artifact cleanup would block until "A" completed, and "A" could not complete until the client artifact cleanup finished.

Fixed by spawning a thread for the entire cleanup, allowing the client's receive pump thread to continue and complete "A", which in turn allows the cleanup to continue and finish.

Leaving in some of the tracing added while tracking this issue down.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.