### PR TITLE
Cancel pending requests when req-resp link is closed by service

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/CBSChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/CBSChannel.java
@@ -61,7 +61,7 @@ public class CBSChannel {
                 new IOperationResult<RequestResponseChannel, Exception>() {
                     @Override
                     public void onComplete(final RequestResponseChannel result) {
-                        result.request(dispatcher, request,
+                        result.request(request,
                                 new IOperationResult<Message, Exception>() {
                                     @Override
                                     public void onComplete(final Message response) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ManagementChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ManagementChannel.java
@@ -54,7 +54,7 @@ public class ManagementChannel {
                 new IOperationResult<RequestResponseChannel, Exception>() {
                     @Override
                     public void onComplete(final RequestResponseChannel result) {
-                        result.request(dispatcher, requestMessage,
+                        result.request(requestMessage,
                                 new IOperationResult<Message, Exception>() {
                                     @Override
                                     public void onComplete(final Message response) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/ConnectionHandler.java
@@ -91,14 +91,8 @@ public final class ConnectionHandler extends BaseHandler {
         final Transport transport = event.getTransport();
         final ErrorCondition condition = transport.getCondition();
 
-        if (condition != null) {
-            if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
-                TRACE_LOGGER.log(Level.WARNING, "Connection.onTransportError: hostname[" + connection.getHostname() + "], error[" + condition.getDescription() + "]");
-            }
-        } else {
-            if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
-                TRACE_LOGGER.log(Level.WARNING, "Connection.onTransportError: hostname[" + connection != null ? connection.getHostname() : "n/a" + "], error[no description returned]");
-            }
+        if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
+            TRACE_LOGGER.log(Level.WARNING, "Connection.onTransportClosed: hostname[" + (connection != null ? connection.getHostname() : "n/a") + "], error[" + (condition != null ? condition.getDescription() : "n/a") + "]");
         }
 
         if (connection != null && connection.getRemoteState() != EndpointState.CLOSED) {
@@ -118,14 +112,8 @@ public final class ConnectionHandler extends BaseHandler {
         final Transport transport = event.getTransport();
         final ErrorCondition condition = transport.getCondition();
 
-        if (condition != null) {
-            if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
-                TRACE_LOGGER.log(Level.WARNING, "Connection.onTransportClosed: hostname[" + connection.getHostname() + "], error[" + condition.getDescription() + "]");
-            }
-        } else {
-            if (TRACE_LOGGER.isLoggable(Level.WARNING)) {
-                TRACE_LOGGER.log(Level.WARNING, "Connection.onTransportClosed: hostname[" + connection != null ? connection.getHostname() : "n/a" + "], error[no description returned]");
-            }
+        if (TRACE_LOGGER.isLoggable(Level.FINE)) {
+            TRACE_LOGGER.log(Level.FINE, "Connection.onTransportClosed: hostname[" + (connection != null ? connection.getHostname() : "n/a") + "], error[" + (condition != null ? condition.getDescription() : "n/a") + "]");
         }
 
         if (connection != null && connection.getRemoteState() != EndpointState.CLOSED) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -124,7 +124,7 @@ public class RequestResponseTest  extends ApiTestBase {
                 new IOperationResult<RequestResponseChannel, Exception>() {
                     @Override
                     public void onComplete(RequestResponseChannel result) {
-                        result.request(dispatcher, request,
+                        result.request(request,
                             new IOperationResult<Message, Exception>() {
                                 @Override
                                 public void onComplete(Message response) {


### PR DESCRIPTION
1. Cancel pending requests when req-resp link is closed by service: this bug resulted in a receive stuck instance (in our internal upgrade testing - which occurs very rarely)
- as the first step of re-creating receive link involves sending a token to service over req-resp link. This response callback never got invoked.

2. run the actual "request" logic directly in request method - instead of enqueing into dispatcher queue - as - by the time this is actually run by dispatcher - the state of send/receive link could change and result into error.