### PR TITLE
Make thread pool non-static.

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
@@ -156,7 +156,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Checkpoint> getCheckpoint(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> getCheckpointSync(partitionId));
+        return this.host.getExecutorService().submit(() -> getCheckpointSync(partitionId));
     }
     
     private Checkpoint getCheckpointSync(String partitionId) throws URISyntaxException, IOException, StorageException
@@ -176,7 +176,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Checkpoint> createCheckpointIfNotExists(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> createCheckpointIfNotExistsSync(partitionId));
+        return this.host.getExecutorService().submit(() -> createCheckpointIfNotExistsSync(partitionId));
     }
     
     private Checkpoint createCheckpointIfNotExistsSync(String partitionId) throws Exception
@@ -197,13 +197,13 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Void> updateCheckpoint(Checkpoint checkpoint)
     {
-    	throw new RuntimeException("Use updateCheckpoint(checkpoint, lease) instead."); 
+        throw new RuntimeException("Use updateCheckpoint(checkpoint, lease) instead.");
     }
     
     @Override
     public Future<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> updateCheckpointSync(lease, checkpoint));
+        return this.host.getExecutorService().submit(() -> updateCheckpointSync(lease, checkpoint));
     }
     
     private Void updateCheckpointSync(Lease lease, Checkpoint checkpoint) throws Exception
@@ -219,7 +219,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Void> deleteCheckpoint(String partitionId)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteCheckpointSync(partitionId));
+        return this.host.getExecutorService().submit(() -> deleteCheckpointSync(partitionId));
     }
     
     private Void deleteCheckpointSync(String partitionId) throws Exception
@@ -258,7 +258,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     
     private Future<Boolean> leaseStoreExists(BlobRequestOptions options)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> this.eventHubContainer.exists(null, options, null));
+        return this.host.getExecutorService().submit(() -> this.eventHubContainer.exists(null, options, null));
     }
 
     @Override
@@ -269,18 +269,18 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     
     private Future<Boolean> createLeaseStoreIfNotExists(BlobRequestOptions options)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> this.eventHubContainer.createIfNotExists(options, null));
+        return this.host.getExecutorService().submit(() -> this.eventHubContainer.createIfNotExists(options, null));
     }
 
     @Override
     public Future<Boolean> deleteLeaseStore()
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteLeaseStoreSync(this.leaseOperationOptions));
+        return this.host.getExecutorService().submit(() -> deleteLeaseStoreSync(this.leaseOperationOptions));
     }
     
     private Future<Boolean> deleteLeaseStore(BlobRequestOptions options)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteLeaseStoreSync(options));
+        return this.host.getExecutorService().submit(() -> deleteLeaseStoreSync(options));
     }
     
     private Boolean deleteLeaseStoreSync(BlobRequestOptions options)
@@ -334,7 +334,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Lease> getLease(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> getLeaseSync(partitionId, this.leaseOperationOptions));
+        return this.host.getExecutorService().submit(() -> getLeaseSync(partitionId, this.leaseOperationOptions));
     }
     
     private AzureBlobLease getLeaseSync(String partitionId, BlobRequestOptions options) throws URISyntaxException, IOException, StorageException
@@ -365,7 +365,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Lease> createLeaseIfNotExists(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> createLeaseIfNotExistsSync(partitionId, this.leaseOperationOptions));
+        return this.host.getExecutorService().submit(() -> createLeaseIfNotExistsSync(partitionId, this.leaseOperationOptions));
     }
     
     private AzureBlobLease createLeaseIfNotExistsSync(String partitionId, BlobRequestOptions options) throws URISyntaxException, IOException, StorageException
@@ -407,7 +407,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Void> deleteLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> deleteLeaseSync((AzureBlobLease)lease));
+        return this.host.getExecutorService().submit(() -> deleteLeaseSync((AzureBlobLease)lease));
     }
     
     private Void deleteLeaseSync(AzureBlobLease lease) throws StorageException
@@ -420,7 +420,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Boolean> acquireLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> acquireLeaseSync((AzureBlobLease)lease));
+        return this.host.getExecutorService().submit(() -> acquireLeaseSync((AzureBlobLease)lease));
     }
     
     private Boolean acquireLeaseSync(AzureBlobLease lease) throws Exception
@@ -488,7 +488,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Boolean> renewLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> renewLeaseSync((AzureBlobLease)lease));
+        return this.host.getExecutorService().submit(() -> renewLeaseSync((AzureBlobLease)lease));
     }
     
     private Boolean renewLeaseSync(AzureBlobLease lease) throws Exception
@@ -520,7 +520,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Boolean> releaseLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> releaseLeaseSync((AzureBlobLease)lease));
+        return this.host.getExecutorService().submit(() -> releaseLeaseSync((AzureBlobLease)lease));
     }
     
     private Boolean releaseLeaseSync(AzureBlobLease lease) throws Exception
@@ -556,7 +556,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     @Override
     public Future<Boolean> updateLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> updateLeaseSync((AzureBlobLease)lease, this.leaseOperationOptions));
+        return this.host.getExecutorService().submit(() -> updateLeaseSync((AzureBlobLease)lease, this.leaseOperationOptions));
     }
     
     public Boolean updateLeaseSync(AzureBlobLease lease, BlobRequestOptions options) throws Exception

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -284,7 +284,7 @@ class EventHubPartitionPump extends PartitionPump
 			// blocks other client calls that we would like to make during cleanup. Specifically, this issue was found when
 			// PartitionReceiver.setReceiveHandler(null).get() was called and never returned.
 			final Throwable capturedError = error;
-			EventProcessorHost.getExecutorService().submit(() -> EventHubPartitionPump.this.onError(capturedError));
+			EventHubPartitionPump.this.host.getExecutorService().submit(() -> EventHubPartitionPump.this.onError(capturedError));
 		}
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -34,14 +34,9 @@ public final class EventProcessorHost
     private EventProcessorOptions processorOptions;
     private PartitionManagerOptions partitionManagerOptions = null;
 
-    // Thread pool is shared among all instances of EventProcessorHost
-    // weOwnExecutor exists to support user-supplied thread pools if we add that feature later.
-    // weOwnExecutor is a boxed Boolean so it can be used to synchronize access to these variables.
-    // executorRefCount is required because the last host must shut down the thread pool if we own it.
-    private static ExecutorService executorService = null;
-    private static int executorRefCount = 0;
-    private static Boolean weOwnExecutor = true;
-    private static boolean autoShutdownExecutor = false;
+    // weOwnExecutor exists to support user-supplied thread pools.
+    private ExecutorService executorService = null;
+    private boolean weOwnExecutor = true;
     
     public final static String EVENTPROCESSORHOST_TRACE = "eventprocessorhost.trace";
 	private static final Logger TRACE_LOGGER = Logger.getLogger(EventProcessorHost.EVENTPROCESSORHOST_TRACE);
@@ -350,38 +345,16 @@ public final class EventProcessorHost
         this.checkpointManager = checkpointManager;
         this.leaseManager = leaseManager;
 
-        synchronized(EventProcessorHost.weOwnExecutor)
+        if (executorService != null)
         {
-	        if (EventProcessorHost.executorService != null)
-	        {
-	        	// An EventProcessorHost has already been instantiated in this process.
-	        	// Ignore any settings provided, just use the existing ExecutorService and
-	        	// related settings.
-	        	
-	        	// If using EventProcessorHost internal ExecutorService, increase the refcount.
-	        	if (EventProcessorHost.weOwnExecutor)
-	        	{
-	        		EventProcessorHost.executorRefCount++;
-	        	}
-	        }
-	        else
-	        {
-		        if (executorService != null)
-		        {
-		        	// User has supplied an ExecutorService, so use that.
-		        	EventProcessorHost.weOwnExecutor = false;
-		        	EventProcessorHost.executorService = executorService;
-		        	// We don't own it so refcount is meaningless.
-		        	// Make sure that auto shutdown is false!
-		        	EventProcessorHost.autoShutdownExecutor = false;
-		        }
-		        else
-		        {
-		        	EventProcessorHost.weOwnExecutor = true;
-		        	EventProcessorHost.executorService = Executors.newCachedThreadPool();
-		        	EventProcessorHost.executorRefCount++;
-		        }
-	        }
+            // User has supplied an ExecutorService, so use that.
+            this.weOwnExecutor = false;
+            this.executorService = executorService;
+        }
+        else
+        {
+            this.weOwnExecutor = true;
+            this.executorService = Executors.newCachedThreadPool();
         }
         
         this.partitionManager = new PartitionManager(this);
@@ -413,7 +386,7 @@ public final class EventProcessorHost
     void setPartitionManager(PartitionManager pm) { this.partitionManager = pm; }
     
     // All of these accessors are for internal use only.
-    static ExecutorService getExecutorService() { return EventProcessorHost.executorService; }
+    ExecutorService getExecutorService() { return this.executorService; }
     ICheckpointManager getCheckpointManager() { return this.checkpointManager; }
     ILeaseManager getLeaseManager() { return this.leaseManager; }
     PartitionManager getPartitionManager() { return this.partitionManager; }
@@ -521,7 +494,7 @@ public final class EventProcessorHost
     		throw new IllegalStateException("Register has already been called on this EventProcessorHost");
     	}
     	
-    	if (EventProcessorHost.executorService.isShutdown() || EventProcessorHost.executorService.isTerminated())
+        if (this.executorService.isShutdown() || this.executorService.isTerminated())
     	{
     		this.logWithHost(Level.SEVERE, "Calling registerEventProcessor/Factory after executor service has been shut down");
     		throw new RejectedExecutionException("EventProcessorHost executor service has been shut down");
@@ -543,7 +516,7 @@ public final class EventProcessorHost
         logWithHost(Level.FINE, "Starting event processing");
         this.processorFactory = factory;
         this.processorOptions = processorOptions;
-        return EventProcessorHost.executorService.submit(() -> this.partitionManager.initialize()); 
+        return this.executorService.submit(() -> this.partitionManager.initialize());
     }
 
     /**
@@ -567,17 +540,10 @@ public final class EventProcessorHost
 	        		stoppingPartitions.get();
 	        	}
 	            
-		        if (EventProcessorHost.weOwnExecutor)
-		        {
-		        	// If there are multiple EventProcessorHosts in one process, only await the shutdown on the last one.
-		        	// Otherwise the first one will block forever here.
-		        	// This could race with stopExecutor() but that is harmless: it is legal to call awaitTermination()
-		        	// at any time, whether executorServer.shutdown() has been called yet or not.
-		        	if ((EventProcessorHost.executorRefCount <= 0) && EventProcessorHost.autoShutdownExecutor)
-		        	{
-		        		EventProcessorHost.executorService.awaitTermination(10, TimeUnit.MINUTES);
-		        	}
-		        }
+                if (this.weOwnExecutor)
+                {
+                    this.executorService.awaitTermination(10, TimeUnit.MINUTES);
+                }
 			}
 	        catch (InterruptedException | ExecutionException e)
 	        {
@@ -591,65 +557,32 @@ public final class EventProcessorHost
     // PartitionManager calls this after all shutdown tasks have been submitted to the ExecutorService.
     void stopExecutor()
     {
-        if (EventProcessorHost.weOwnExecutor)
+        if (this.weOwnExecutor)
         {
-        	synchronized(EventProcessorHost.weOwnExecutor)
-        	{
-        		EventProcessorHost.executorRefCount--;
-        		
-        		if ((EventProcessorHost.executorRefCount <= 0) && EventProcessorHost.autoShutdownExecutor)
-        		{
-        			// It is OK to call shutdown() here even though threads are still running.
-        			// Shutdown() causes the executor to stop accepting new tasks, but existing tasks will
-        			// run to completion. The pool will terminate when all existing tasks finish.
-        			// By this point all new tasks generated by the shutdown have been submitted.
-        			EventProcessorHost.executorService.shutdown();
-        		}
-        	}
+			// It is OK to call shutdown() here even if threads are still running.
+			// Shutdown() causes the executor to stop accepting new tasks, but existing tasks will
+			// run to completion. The pool will terminate when all existing tasks finish.
+			// By this point all new tasks generated by the shutdown have been submitted.
+			this.executorService.shutdown();
         }
     }
-
     
     /**
-     * EventProcessorHost can automatically shut down its internal ExecutorService when the last host shuts down
-     * due to an unregisterEventProcessor() call. However, doing so means that any EventProcessorHost instances
-     * created after that will be unable to function. Set this option to true only if you are sure that you will
-     * only ever call unregisterEventProcess() when the process is shutting down.
-     * <p>
-     * If you leave this option as the default false, then you should call forceExecutorShutdown() at the appropriate time.
-     * <p>
-     * If using a user-supplied ExecutorService, then this option must remain false.
-     * 
-     * @param auto  true for automatic shutdown, false for manual via forceExecutorShutdown()
+     * This method is no longer required and does nothing. If the user supplies a thread pool, we will never
+     * shut it down. The internal thread pool is per-instance now, so it is always safe to auto shut down.
      */
+    @Deprecated
     public static void setAutoExecutorShutdown(boolean auto)
     {
-    	if ((EventProcessorHost.weOwnExecutor == false) && (auto == true))
-    	{
-    		throw new IllegalArgumentException("Automatic executor shutdown not possible with user-supplied executor");
-    	}
-    	EventProcessorHost.autoShutdownExecutor = auto;
     }
 
     /**
-     * If you do not want to use the automatic shutdown option, then you must call forceExecutorShutdown() during
-     * process termination, after the last call to unregisterEventProcessor() has returned. Be sure that you will
-     * not need to create any new EventProcessorHost instances, because calling this method means that any new
-     * instances will fail when a register* method is called.
-     * <p>
-     * If using a user-supplied ExecutorService, calling this method is not required and has no effect.
-     * 
-     * @param secondsToWait  How long to wait for the ExecutorService to shut down
-     * @throws InterruptedException
+     * This method is no longer required and does nothing. If the user supplies a thread pool, we will never
+     * shut it down. The internal thread pool is per-instance now, so it is always safe to auto shut down.
      */
+    @Deprecated
     public static void forceExecutorShutdown(long secondsToWait) throws InterruptedException
     {
-    	if (EventProcessorHost.weOwnExecutor && (EventProcessorHost.executorService != null))
-		{
-			EventProcessorHost.executorService.shutdown();
-			EventProcessorHost.executorService.awaitTermination(secondsToWait, TimeUnit.SECONDS);
-		}
-    	// else just ignore
     }
 
     

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -35,8 +35,8 @@ public final class EventProcessorHost
     private PartitionManagerOptions partitionManagerOptions = null;
 
     // weOwnExecutor exists to support user-supplied thread pools.
-    private ExecutorService executorService = null;
-    private boolean weOwnExecutor = true;
+    private final ExecutorService executorService;
+    private final boolean weOwnExecutor;
     
     public final static String EVENTPROCESSORHOST_TRACE = "eventprocessorhost.trace";
 	private static final Logger TRACE_LOGGER = Logger.getLogger(EventProcessorHost.EVENTPROCESSORHOST_TRACE);

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -118,7 +118,7 @@ class PartitionManager
     		throw e;
     	}
     	
-    	this.partitionsFuture = EventProcessorHost.getExecutorService().submit(() -> runAndCleanUp());
+        this.partitionsFuture = this.host.getExecutorService().submit(() -> runAndCleanUp());
     	
     	return null;
     }
@@ -162,11 +162,6 @@ class PartitionManager
     	this.host.logWithHost(Level.FINE, "Shutting down all pumps");
     	Iterable<Future<?>> pumpRemovals = this.pump.removeAllPumps(CloseReason.Shutdown);
     	
-    	// All of the shutdown threads have been launched, we can shut down the executor now.
-    	// Shutting down the executor only prevents new tasks from being submitted.
-    	// We can't wait for executor termination here because this thread is in the executor.
-    	this.host.stopExecutor();
-    	
     	// Wait for shutdown threads.
     	for (Future<?> removal : pumpRemovals)
     	{
@@ -190,6 +185,10 @@ class PartitionManager
 			}
     	}
     	
+        // All of the shutdown threads are done, we can shut down the executor now.
+        // We can't wait for executor termination here because this thread is in the executor.
+        this.host.stopExecutor();
+
     	this.host.logWithHost(Level.FINE, "Partition manager exiting");
     	
     	return null;

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -59,7 +59,7 @@ class Pump
     private void createNewPump(String partitionId, Lease lease) throws Exception
     {
 		PartitionPump newPartitionPump = new EventHubPartitionPump(this.host, this, lease);
-		EventProcessorHost.getExecutorService().submit(new Callable<Void>()
+		this.host.getExecutorService().submit(new Callable<Void>()
 			{
 				@Override
 				public Void call() throws Exception
@@ -84,7 +84,7 @@ class Pump
     	if (capturedPump != null)
     	{
 			this.host.logWithHostAndPartition(Level.FINE, partitionId, "closing pump for reason " + reason.toString());
-			retval = EventProcessorHost.getExecutorService().submit(() -> capturedPump.shutdown(reason));
+			retval = this.host.getExecutorService().submit(() -> capturedPump.shutdown(reason));
     		
     		this.host.logWithHostAndPartition(Level.FINE, partitionId, "removing pump");
     		this.pumpStates.remove(partitionId);

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
@@ -73,7 +73,7 @@ class DummyPump extends Pump
 	@Override
     public Future<?> removePump(String partitionId, final CloseReason reason)
     {
-		return EventProcessorHost.getExecutorService().submit(() -> this.pumps.remove(partitionId));
+		return this.host.getExecutorService().submit(() -> this.pumps.remove(partitionId));
     }
     
 	@Override

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
@@ -6,6 +6,8 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 
@@ -27,9 +29,11 @@ import java.util.logging.Level;
 public class InMemoryCheckpointManager implements ICheckpointManager
 {
     private EventProcessorHost host;
+    private ExecutorService executor;
 
     public InMemoryCheckpointManager()
     {
+    	this.executor = Executors.newCachedThreadPool();
     }
 
     // This object is constructed before the EventProcessorHost and passed as an argument to
@@ -42,7 +46,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Boolean> checkpointStoreExists()
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> checkpointStoreExistsSync());
+    	return this.executor.submit(() -> checkpointStoreExistsSync());
     }
     
     private Boolean checkpointStoreExistsSync()
@@ -53,7 +57,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Boolean> createCheckpointStoreIfNotExists()
     {
-        return EventProcessorHost.getExecutorService().submit(() -> createCheckpointStoreIfNotExistsSync());
+        return this.executor.submit(() -> createCheckpointStoreIfNotExistsSync());
     }
 
     private Boolean createCheckpointStoreIfNotExistsSync()
@@ -65,7 +69,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Boolean> deleteCheckpointStore()
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteCheckpointStoreSync());
+    	return this.executor.submit(() -> deleteCheckpointStoreSync());
     }
     
     private Boolean deleteCheckpointStoreSync()
@@ -77,7 +81,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Checkpoint> getCheckpoint(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> getCheckpointSync(partitionId));
+        return this.executor.submit(() -> getCheckpointSync(partitionId));
     }
     
     private Checkpoint getCheckpointSync(String partitionId)
@@ -104,7 +108,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Checkpoint> createCheckpointIfNotExists(String partitionId)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> createCheckpointIfNotExistsSync(partitionId));
+    	return this.executor.submit(() -> createCheckpointIfNotExistsSync(partitionId));
     }
     
     private Checkpoint createCheckpointIfNotExistsSync(String partitionId)
@@ -149,7 +153,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> updateCheckpointSync(checkpoint.getPartitionId(), checkpoint.getOffset(), checkpoint.getSequenceNumber()));
+        return this.executor.submit(() -> updateCheckpointSync(checkpoint.getPartitionId(), checkpoint.getOffset(), checkpoint.getSequenceNumber()));
     }
 
     private Void updateCheckpointSync(String partitionId, String offset, long sequenceNumber)
@@ -171,7 +175,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     @Override
     public Future<Void> deleteCheckpoint(String partitionId)
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteCheckpointSync(partitionId));
+    	return this.executor.submit(() -> deleteCheckpointSync(partitionId));
     }
     
     private Void deleteCheckpointSync(String partitionId)

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
@@ -7,6 +7,8 @@ package com.microsoft.azure.eventprocessorhost;
 
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 
@@ -28,12 +30,14 @@ import java.util.logging.Level;
 public class InMemoryLeaseManager implements ILeaseManager
 {
     private EventProcessorHost host;
+    private ExecutorService executor;
 
     private final static int leaseDurationInMillieconds = 30 * 1000;	   // thirty seconds
     private final static int leaseRenewIntervalInMilliseconds = 10 * 1000; // ten seconds
 
     public InMemoryLeaseManager()
     {
+    	this.executor = Executors.newCachedThreadPool();
     }
 
     // This object is constructed before the EventProcessorHost and passed as an argument to
@@ -58,7 +62,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> leaseStoreExists()
     {
-        return EventProcessorHost.getExecutorService().submit(() -> leaseStoreExistsSync());
+        return this.executor.submit(() -> leaseStoreExistsSync());
     }
     
     private Boolean leaseStoreExistsSync()
@@ -69,7 +73,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> createLeaseStoreIfNotExists()
     {
-        return EventProcessorHost.getExecutorService().submit(() -> createLeaseStoreIfNotExistsSync());
+        return this.executor.submit(() -> createLeaseStoreIfNotExistsSync());
     }
 
     private Boolean createLeaseStoreIfNotExistsSync()
@@ -81,7 +85,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> deleteLeaseStore()
     {
-    	return EventProcessorHost.getExecutorService().submit(() -> deleteLeaseStoreSync());
+    	return this.executor.submit(() -> deleteLeaseStoreSync());
     }
     
     private Boolean deleteLeaseStoreSync()
@@ -93,7 +97,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Lease> getLease(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> getLeaseSync(partitionId));
+        return this.executor.submit(() -> getLeaseSync(partitionId));
     }
 
     private InMemoryLease getLeaseSync(String partitionId)
@@ -127,7 +131,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Lease> createLeaseIfNotExists(String partitionId)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> createLeaseIfNotExistsSync(partitionId));
+        return this.executor.submit(() -> createLeaseIfNotExistsSync(partitionId));
     }
 
     private InMemoryLease createLeaseIfNotExistsSync(String partitionId)
@@ -154,7 +158,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Void> deleteLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> deleteLeaseSync(lease));
+        return this.executor.submit(() -> deleteLeaseSync(lease));
     }
     
     private Void deleteLeaseSync(Lease lease)
@@ -167,7 +171,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> acquireLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> acquireLeaseSync((InMemoryLease)lease));
+        return this.executor.submit(() -> acquireLeaseSync((InMemoryLease)lease));
     }
 
     private Boolean acquireLeaseSync(InMemoryLease lease)
@@ -219,7 +223,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> renewLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> renewLeaseSync((InMemoryLease)lease));
+        return this.executor.submit(() -> renewLeaseSync((InMemoryLease)lease));
     }
     
     private Boolean renewLeaseSync(InMemoryLease lease)
@@ -258,7 +262,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> releaseLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> releaseLeaseSync((InMemoryLease)lease));
+        return this.executor.submit(() -> releaseLeaseSync((InMemoryLease)lease));
     }
     
     private Boolean releaseLeaseSync(InMemoryLease lease)
@@ -295,7 +299,7 @@ public class InMemoryLeaseManager implements ILeaseManager
     @Override
     public Future<Boolean> updateLease(Lease lease)
     {
-        return EventProcessorHost.getExecutorService().submit(() -> updateLeaseSync((InMemoryLease)lease));
+        return this.executor.submit(() -> updateLeaseSync((InMemoryLease)lease));
     }
     
     private Boolean updateLeaseSync(InMemoryLease lease)

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PartitionManagerTest.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PartitionManagerTest.java
@@ -381,7 +381,7 @@ public class PartitionManagerTest
 	{
 		try
 		{
-			EventProcessorHost.getExecutorService().submit(() -> this.partitionManagers[index].initialize()).get();
+			this.hosts[index].getExecutorService().submit(() -> this.partitionManagers[index].initialize()).get();
 			this.running[index] = true;
 		}
 		catch (Exception e)
@@ -452,12 +452,12 @@ public class PartitionManagerTest
 		@Override
 	    String[] getPartitionIds()
 	    {
-			ArrayList<String> ids = new ArrayList<String>();
+			String ids[] = new String[this.partitionCount];
 			for (int i = 0; i < this.partitionCount; i++)
 			{
-				ids.add(String.valueOf(i));
+				ids[i] = String.valueOf(i);
 			}
-			return (String[])ids.toArray();
+			return ids;
 	    }
 	    
 		@Override

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
@@ -64,7 +64,7 @@ public class Repros extends TestBase
 		{
 			utils.sendToAny("conflict-" + i++, 10);
 			System.out.println("\n." + factory1.getEventsReceivedCount() + "." + factory2.getEventsReceivedCount() + ":" +
-					((ThreadPoolExecutor)EventProcessorHost.getExecutorService()).getPoolSize() + ":" +
+					((ThreadPoolExecutor)host1.getExecutorService()).getPoolSize() + "." + ((ThreadPoolExecutor)host2.getExecutorService()).getPoolSize() + ":" +
 					Thread.activeCount());
 			Thread.sleep(100);
 		}


### PR DESCRIPTION
## Description

A shared thread pool makes some sense if one regards event processor host as a unitary subsystem, but there is no compelling architectural reason to do so and nothing in the logic requires it. Making instances of EventProcessorHost completely independent increases user flexibility and simplifies the code.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.