### PR TITLE
Removed exception swallowing in EventHubClient

### DIFF
--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
@@ -28,6 +28,7 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
+import org.omg.CORBA.INTERNAL;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -50,7 +51,7 @@ class RealEventHubUtilities
 	{
 	}
 	
-	ArrayList<String> setup(int fakePartitions) throws EventHubException, IOException
+	ArrayList<String> setup(int fakePartitions) throws EventHubException, IOException, ExecutionException, InterruptedException
 	{
 		ArrayList<String> partitionIds = setupWithoutSenders(fakePartitions);
 		
@@ -60,7 +61,8 @@ class RealEventHubUtilities
 		return partitionIds;
 	}
 	
-	ArrayList<String> setupWithoutSenders(int fakePartitions) throws EventHubException, IOException
+	ArrayList<String> setupWithoutSenders(int fakePartitions)
+            throws EventHubException, IOException, ExecutionException, InterruptedException
 	{
 		// Get the connection string from the environment
 		ehCacheCheck();
@@ -128,7 +130,7 @@ class RealEventHubUtilities
 		return this.consumerGroup;
 	}
 	
-	void sendToAny(String body, int count) throws EventHubException
+	void sendToAny(String body, int count) throws EventHubException, ExecutionException, InterruptedException
 	{
 		for (int i = 0; i < count; i++)
 		{
@@ -136,13 +138,14 @@ class RealEventHubUtilities
 		}
 	}
 	
-	void sendToAny(String body) throws EventHubException
+	void sendToAny(String body) throws EventHubException, ExecutionException, InterruptedException
 	{
 		EventData event = new EventData(body.getBytes());
 		this.client.sendSync(event);
 	}
 	
-	void sendToPartition(String partitionId, String body) throws IllegalArgumentException, EventHubException
+	void sendToPartition(String partitionId, String body)
+			throws IllegalArgumentException, EventHubException, ExecutionException, InterruptedException
 	{
 		EventData event = new EventData(body.getBytes());
 		PartitionSender sender = null;
@@ -158,7 +161,8 @@ class RealEventHubUtilities
 		sender.sendSync(event);
 	}
 	
-    ArrayList<String> getPartitionIdsForTest() throws EventHubException, IOException
+    ArrayList<String> getPartitionIdsForTest()
+            throws EventHubException, IOException, ExecutionException, InterruptedException
     {
     	if (this.cachedPartitionIds == null)
     	{

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
@@ -28,7 +28,6 @@ import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import org.omg.CORBA.INTERNAL;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;

--- a/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
+++ b/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.eventhubs.extensions.appender;
 
 import java.io.*;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 import org.apache.logging.log4j.core.appender.*;
 
@@ -23,7 +24,7 @@ public final class EventHubsManager extends AbstractManager
 		this.eventHubConnectionString = eventHubConnectionString;
 	}
 	
-	public void send(final byte[] msg) throws EventHubException
+	public void send(final byte[] msg) throws EventHubException, ExecutionException, InterruptedException
 	{
 		if (msg != null)
 		{
@@ -32,7 +33,7 @@ public final class EventHubsManager extends AbstractManager
 		}
 	}
 	
-	public void send(final Iterable<byte[]> messages) throws EventHubException
+	public void send(final Iterable<byte[]> messages) throws EventHubException, ExecutionException, InterruptedException
 	{
 		if (messages != null)
 		{
@@ -46,7 +47,7 @@ public final class EventHubsManager extends AbstractManager
 		}
 	}
 
-	public void startup() throws EventHubException, IOException
+	public void startup() throws EventHubException, IOException, ExecutionException, InterruptedException
 	{
 		this.eventHubSender = EventHubClient.createFromConnectionStringSync(this.eventHubConnectionString);
 	}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -52,7 +52,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws IOException         If the underlying Proton-J layer encounter network errors.
      */
     public static EventHubClient createFromConnectionStringSync(final String connectionString)
-            throws EventHubException, IOException {
+            throws EventHubException, IOException, ExecutionException, InterruptedException {
         return createFromConnectionStringSync(connectionString, null);
     }
 
@@ -66,7 +66,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws IOException         If the underlying Proton-J layer encounter network errors.
      */
     public static EventHubClient createFromConnectionStringSync(final String connectionString, final RetryPolicy retryPolicy)
-            throws EventHubException, IOException {
+            throws EventHubException, IOException, ExecutionException, InterruptedException {
         try {
             return createFromConnectionString(connectionString, retryPolicy).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -87,9 +87,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -194,7 +194,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final void sendSync(final EventData data)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             this.send(data).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -215,6 +215,8 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
+
+            throw exception;
         }
     }
 
@@ -267,7 +269,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final void sendSync(final Iterable<EventData> eventDatas)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             this.send(eventDatas).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -288,6 +290,8 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
+
+            throw exception;
         }
     }
 
@@ -361,7 +365,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final void sendSync(final EventData eventData, final String partitionKey)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             this.send(eventData, partitionKey).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -382,6 +386,8 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
+
+            throw exception;
         }
     }
 
@@ -440,7 +446,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final void sendSync(final Iterable<EventData> eventDatas, final String partitionKey)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             this.send(eventDatas, partitionKey).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -461,6 +467,8 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
+
+            throw exception;
         }
     }
 
@@ -516,7 +524,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionSender createPartitionSenderSync(final String partitionId)
-            throws EventHubException, IllegalArgumentException {
+            throws EventHubException, IllegalArgumentException, ExecutionException, InterruptedException {
         try {
             return this.createPartitionSender(partitionId).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -537,9 +545,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -574,7 +582,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, startingOffset).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -595,9 +603,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -631,7 +639,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -652,9 +660,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -686,7 +694,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, dateTime).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -707,9 +715,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -741,7 +749,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, startingOffset, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -762,9 +770,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -800,7 +808,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -821,9 +829,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -857,7 +865,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createReceiver(consumerGroupName, partitionId, dateTime, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -878,9 +886,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -913,7 +921,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, epoch).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -934,9 +942,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -978,7 +986,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -999,9 +1007,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -1043,7 +1051,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -1064,9 +1072,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -1108,7 +1116,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, epoch, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -1129,9 +1137,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -1175,7 +1183,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -1196,9 +1204,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**
@@ -1242,7 +1250,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     @Override
     public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
+            throws EventHubException, ExecutionException, InterruptedException {
         try {
             return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -1263,9 +1271,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
                 throw new EventHubException(true, throwable);
             }
-        }
 
-        return null;
+            throw exception;
+        }
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -6,102 +6,103 @@ package com.microsoft.azure.eventhubs;
 
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 public interface IEventHubClient {
     void sendSync(EventData data)
-            throws EventHubException;
+            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<Void> send(EventData data);
 
     void sendSync(Iterable<EventData> eventDatas)
-            throws EventHubException;
+            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<Void> send(Iterable<EventData> eventDatas);
 
     void sendSync(EventData eventData, String partitionKey)
-            throws EventHubException;
+            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<Void> send(EventData eventData, String partitionKey);
 
     void sendSync(Iterable<EventData> eventDatas, String partitionKey)
-            throws EventHubException;
+            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<Void> send(Iterable<EventData> eventDatas, String partitionKey);
 
     PartitionSender createPartitionSenderSync(String partitionId)
-            throws EventHubException, IllegalArgumentException;
+            throws EventHubException, IllegalArgumentException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionSender> createPartitionSender(String partitionId)
-                    throws EventHubException;
+                    throws EventHubException, ExecutionException, InterruptedException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset)
-                            throws EventHubException;
+                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset)
                                     throws EventHubException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive)
-                                            throws EventHubException;
+                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive)
                                                     throws EventHubException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, Instant dateTime)
-                                                            throws EventHubException;
+                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, Instant dateTime)
                                                                     throws EventHubException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, ReceiverOptions receiverOptions)
-                                                                            throws EventHubException;
+                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, ReceiverOptions receiverOptions)
                                                                                     throws EventHubException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, ReceiverOptions receiverOptions)
-                                                                                            throws EventHubException;
+                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, ReceiverOptions receiverOptions)
                                                                                                     throws EventHubException;
 
     PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, ReceiverOptions receiverOptions)
-                                                                                                            throws EventHubException;
+                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, Instant dateTime, ReceiverOptions receiverOptions)
                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, long epoch)
-                                                                                                                            throws EventHubException;
+                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, long epoch)
                                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch)
-                                                                                                                                            throws EventHubException;
+                                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch)
                                                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, long epoch)
-                                                                                                                                                            throws EventHubException;
+                                                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, Instant dateTime, long epoch)
                                                                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                            throws EventHubException;
+                                                                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, long epoch, ReceiverOptions receiverOptions)
                                                                                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                            throws EventHubException;
+                                                                                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch, ReceiverOptions receiverOptions)
                                                                                                                                                                                                     throws EventHubException;
 
     PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                                            throws EventHubException;
+                                                                                                                                                                                                            throws EventHubException, ExecutionException, InterruptedException;
 
     CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, Instant dateTime, long epoch, ReceiverOptions receiverOptions)
                                                                                                                                                                                                                     throws EventHubException;

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReceiverEpochTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReceiverEpochTest.java
@@ -35,7 +35,7 @@ public class ReceiverEpochTest extends ApiTestBase
 	PartitionReceiver receiver;
 	
 	@BeforeClass
-	public static void initializeEventHub() throws EventHubException, IOException
+	public static void initializeEventHub() throws EventHubException, IOException, ExecutionException, InterruptedException
 	{
 		final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString());

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
@@ -62,7 +62,7 @@ public class ReceiveParallelManualTest extends ApiTestBase
             PartitionReceiver offsetReceiver1 = null;
             try {
                 offsetReceiver1 = ehClient.createReceiverSync(cgName, sPartitionId, PartitionReceiver.START_OF_STREAM, false);
-            } catch (EventHubException e) {
+            } catch (EventHubException | ExecutionException | InterruptedException e) {
                 e.printStackTrace();
             }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
@@ -33,14 +33,14 @@ public class ReceivePumpEventHubTest extends ApiTestBase
 	PartitionReceiver receiver;
 	
 	@BeforeClass
-	public static void initializeEventHub()  throws EventHubException, IOException
+	public static void initializeEventHub()  throws EventHubException, IOException, ExecutionException, InterruptedException
 	{
 		final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString());
 	}
 	
 	@Before
-	public void initializeTest() throws EventHubException
+	public void initializeTest() throws EventHubException, ExecutionException, InterruptedException
 	{
 		receiver = ehClient.createReceiverSync(cgName, partitionId, Instant.now());
 	}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
@@ -42,7 +42,7 @@ public class ReceiveTest extends ApiTestBase
 	}
 	
 	@Test()
-	public void testReceiverStartOfStreamFilters() throws EventHubException
+	public void testReceiverStartOfStreamFilters() throws EventHubException, ExecutionException, InterruptedException
 	{
 		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.START_OF_STREAM, false);
 		Iterable<EventData> startingEventsUsingOffsetReceiver = offsetReceiver.receiveSync(100);
@@ -80,7 +80,7 @@ public class ReceiveTest extends ApiTestBase
 	}
 
 	@Test()
-	public void testReceiverOffsetInclusiveFilter() throws EventHubException
+	public void testReceiverOffsetInclusiveFilter() throws EventHubException, ExecutionException, InterruptedException
 	{
 		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
 		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
@@ -96,7 +96,7 @@ public class ReceiveTest extends ApiTestBase
 	}
 	
 	@Test()
-	public void testReceiverOffsetNonInclusiveFilter() throws EventHubException
+	public void testReceiverOffsetNonInclusiveFilter() throws EventHubException, ExecutionException, InterruptedException
 	{
 		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
 		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
@@ -111,7 +111,7 @@ public class ReceiveTest extends ApiTestBase
 	}
 	
 	@Test()
-	public void testReceivedBodyAndProperties() throws EventHubException
+	public void testReceivedBodyAndProperties() throws EventHubException, ExecutionException, InterruptedException
 	{
 		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.END_OF_STREAM);
 		datetimeReceiver.setReceiveTimeout(Duration.ofSeconds(5));

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverIdentifierTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverIdentifierTest.java
@@ -8,6 +8,7 @@ import java.time.Instant;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ExecutionException;
 
 import com.microsoft.azure.eventhubs.QuotaExceededException;
 import org.junit.AfterClass;
@@ -44,7 +45,7 @@ public class ReceiverIdentifierTest extends ApiTestBase {
     }
 
     @Test()
-    public void testReceiverIdentierShowsUpInQuotaErrors() throws EventHubException {
+    public void testReceiverIdentierShowsUpInQuotaErrors() throws EventHubException, ExecutionException, InterruptedException {
 
         final String receiverIdentifierPrefix = UUID.randomUUID().toString();
         for (int receiverCount = 0; receiverCount < 5; receiverCount ++) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -240,7 +240,7 @@ public class RequestResponseTest  extends ApiTestBase {
     }
     
     @Test
-    public void testGetRuntimesBadHub() throws EventHubException, IOException {
+    public void testGetRuntimesBadHub() throws EventHubException, IOException, ExecutionException, InterruptedException {
     	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder(connectionString.getEndpoint(), "NOHUBZZZZZ",
     			connectionString.getSasKeyName(), connectionString.getSasKey());
     	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString());
@@ -291,7 +291,7 @@ public class RequestResponseTest  extends ApiTestBase {
     }
     
     @Test
-    public void testGetRuntimesBadKeyname() throws EventHubException, IOException {
+    public void testGetRuntimesBadKeyname() throws EventHubException, IOException, ExecutionException, InterruptedException {
     	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder(connectionString.getEndpoint(), connectionString.getEntityPath(),
     			"xxxnokeyxxx", connectionString.getSasKey());
     	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString());

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SasTokenReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SasTokenReceiveTest.java
@@ -14,6 +14,8 @@ import org.junit.Test;
 import com.microsoft.azure.eventhubs.lib.SasTokenTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
 
+import java.util.concurrent.ExecutionException;
+
 public class SasTokenReceiveTest extends SasTokenTestBase {
     
     private static ReceiveTest receiveTest;
@@ -30,8 +32,7 @@ public class SasTokenReceiveTest extends SasTokenTestBase {
     }
     
     @Test()
-    public void testReceiverStartOfStreamFilters() throws EventHubException {
-        
+    public void testReceiverStartOfStreamFilters() throws EventHubException, ExecutionException, InterruptedException {
         receiveTest.testReceiverStartOfStreamFilters();
     }
     


### PR DESCRIPTION
close #135

All Execution Exceptions and Interrupted Exceptions thrown in EventHubClient are now thrown to the user.