### PR TITLE
Adding dedicated send APIs for EventDataBatch

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/BatchOptions.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/BatchOptions.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.eventhubs;
+
+import java.util.function.Consumer;
+
+/**
+ * BatchOptions is used to create {@link EventDataBatch}es.
+ *
+ * If you're creating {@link EventDataBatch}es with {@link EventHubClient}, then you can set a partitionKey and maxMessageSize
+ * using the .with() method. Alternatively, if you'd like the default settings, simply construct BatchOptions with the void constructor.
+ * Default settings:
+ *      - partitionKey is null
+ *      - maxMessageSize is the maximum allowed size
+ *
+ * If you're creating {@link EventDataBatch}es with {@link PartitionSender}, then you can only set a maxMessageSize
+ * using the .with() method. Alternatively, if you'd like the default settings, simply construct BatchOptions with the void constructor.
+ * Default settings:
+ *      - maxMessageSize is the maximum allowed size
+ *      - Note: if you set a partition key, an {@link IllegalArgumentException} will be thrown.
+ *
+ * To construct either type of batch, create a {@link BatchOptions} object and pass it into the appropriate
+ * createBatch method. If using {@link PartitionSender}, then use ({@link PartitionSender#createBatch(BatchOptions)}.
+ * If using {@link EventHubClient}, then use {@link EventHubClient#createBatch(BatchOptions)}.
+ *
+ * <pre>
+ *     {@code
+ *     // Note: For all examples, 'client' is an instance of EventHubClient. The usage is the same for PartitionSender,
+ *     however, you can NOT set a partition key when using PartitionSender
+ *
+ *     // Create EventDataBatch with defaults
+ *     BatchOptions options = new BatchOptions()
+ *     EventDataBatch edb1 = client.createBatch(options);
+ *
+ *     // Create EventDataBatch with custom partitionKey
+ *     BatchOptions options = new BatchOptions().with( options -> options.partitionKey = "foo");
+ *     EventDataBatch edb2 = client.createBatch(options);
+ *
+ *     // Create EventDataBatch with custom partitionKey and maxMessageSize
+ *     BatchOptions options = new BatchOptions().with ( options -> {
+ *         options.partitionKey = "foo";
+ *         options.maxMessageSize = 100 * 1024;
+ *     };
+ *     EventDataBatch edb3 = client.createBatch(options);
+ * </pre>
+ */
+public final class BatchOptions {
+    public String partitionKey = null;
+    public Integer maxMessageSize = null;
+
+    public final BatchOptions with(Consumer<BatchOptions> builderFunction) {
+        builderFunction.accept(this);
+        return this;
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 /**
  * Helper class for creating a batch/collection of EventData objects to be used while Sending to EventHubs
  */
-public final class EventDataBatch implements Iterable<EventData> {
+public final class EventDataBatch {
 
     private final int maxMessageSize;
     private final String partitionKey;
@@ -60,7 +60,6 @@ public final class EventDataBatch implements Iterable<EventData> {
         return true;
     }
 
-    @Override
     public Iterator<EventData> iterator() {
 
         return this.events.iterator();
@@ -76,7 +75,7 @@ public final class EventDataBatch implements Iterable<EventData> {
         return this.partitionKey;
     }
 
-    private final int getSize(final EventData eventData, final boolean isFirst) {
+    private int getSize(final EventData eventData, final boolean isFirst) {
 
         final Message amqpMessage = this.partitionKey != null ? eventData.toAmqpMessage(this.partitionKey) : eventData.toAmqpMessage();
         int eventSize = amqpMessage.encode(this.eventBytes, 0, maxMessageSize); // actual encoded bytes size

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 /**
  * Helper class for creating a batch/collection of EventData objects to be used while Sending to EventHubs
  */
-public final class EventDataBatch {
+public class EventDataBatch {
 
     private final int maxMessageSize;
     private final String partitionKey;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
@@ -13,7 +13,7 @@ import java.util.LinkedList;
 /**
  * Helper class for creating a batch/collection of EventData objects to be used while Sending to EventHubs
  */
-public class EventDataBatch {
+public final class EventDataBatch {
 
     private final int maxMessageSize;
     private final String partitionKey;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -76,20 +76,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -159,7 +153,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
                 Thread.currentThread().interrupt();
             }
 
-            Throwable throwable = exception.getCause();
+            final Throwable throwable = exception.getCause();
             if (throwable instanceof EventHubException) {
                 throw (EventHubException) throwable;
             } else if (throwable instanceof RuntimeException) {
@@ -171,6 +165,16 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     }
 
     /**
+     * Creates an Empty Collection of {@link EventData}.
+     *
+     * @return the empty {@link EventDataBatch}, after negotiating maximum message size with EventHubs service
+     * @throws EventHubException if the Microsoft Azure Event Hubs service encountered problems during the operation.
+     */
+    public final EventDataBatch createBatch() throws EventHubException {
+        return this.createBatch(null);
+    }
+
+    /**
      * Synchronous version of {@link #send(EventData)}.
      *
      * @param data the {@link EventData} to be sent.
@@ -179,8 +183,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws UnresolvedAddressException   if there are Client to Service network connectivity issues, if the Azure DNS resolution of the ServiceBus Namespace fails (ex: namespace deleted etc.)
      */
     @Override
-    public final void sendSync(final EventData data)
-            throws EventHubException {
+    public final void sendSync(final EventData data) throws EventHubException {
         try {
             this.send(data).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -190,16 +193,12 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }
@@ -252,8 +251,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws UnresolvedAddressException   if there are Client to Service network connectivity issues, if the Azure DNS resolution of the ServiceBus Namespace fails (ex: namespace deleted etc.)
      */
     @Override
-    public final void sendSync(final Iterable<EventData> eventDatas)
-            throws EventHubException {
+    public final void sendSync(final Iterable<EventData> eventDatas) throws EventHubException {
         try {
             this.send(eventDatas).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -263,16 +261,12 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }
@@ -387,8 +381,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws EventHubException          if Service Bus service encountered problems during the operation.
      */
     @Override
-    public final void sendSync(final EventData eventData, final String partitionKey)
-            throws EventHubException {
+    public final void sendSync(final EventData eventData, final String partitionKey) throws EventHubException {
         try {
             this.send(eventData, partitionKey).get();
         } catch (InterruptedException | ExecutionException exception) {
@@ -398,16 +391,12 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }
@@ -477,16 +466,12 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }
@@ -549,20 +534,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -607,20 +586,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -664,20 +637,15 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
-        }
 
-        return null;
+        }
     }
 
     /**
@@ -719,20 +687,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -774,20 +736,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -833,20 +789,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -890,20 +840,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -946,20 +890,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -1011,20 +949,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -1076,20 +1008,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -1141,20 +1067,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -1208,20 +1128,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**
@@ -1275,20 +1189,14 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
-
-        return null;
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -4,7 +4,6 @@
  */
 package com.microsoft.azure.eventhubs;
 
-import java.awt.*;
 import java.io.IOException;
 import java.nio.channels.UnresolvedAddressException;
 import java.security.InvalidKeyException;
@@ -149,10 +148,12 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      *     EventDataBatch edb2 = ehClient.new BatchBuilder().with( options -> {
      *         options.partitionKey = "foo";
      *         options.maxMessageSize = 256;
-     *     }
+     *     }).createBatch();
      *
      *     // Create EventDataBatch with user-defined partitionKey
-     *     EventDataBatch edb3 = ehClient.new BatchBuilder().with( options -> options.partitionKey = "foo");
+     *     EventDataBatch edb3 = ehClient.new BatchBuilder()
+     *          .with( options -> options.partitionKey = "foo")
+     *          .createBatch();
      * </pre>
      */
     public final class BatchBuilder {
@@ -172,7 +173,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
         /**
          * Creates an Empty Collection of {@link EventData}.
-         * The same partitionKey must be used while sending these events using {@link EventHubClient#send(Iterable)}.
+         * The same partitionKey must be used while sending these events using {@link EventHubClient#send(EventDataBatch)}.
          *
          * @return the empty {@link EventDataBatch}, after negotiating maximum message size with EventHubs service
          * @throws EventHubException if the Microsoft Azure Event Hubs service encountered problems during the operation.

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -148,7 +148,8 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             }
 
             if (options.maxMessageSize > maxSize) {
-                throw new IllegalArgumentException("The maxMessageSize set in BatchOptions is too large.");
+                throw new IllegalArgumentException("The maxMessageSize set in BatchOptions is too large. You set a maxMessageSize of " +
+                    options.maxMessageSize + ". The maximum allowed size is " + maxSize + ".");
             }
 
             return new EventDataBatch(options.maxMessageSize, options.partitionKey);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -161,9 +161,11 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             Throwable throwable = exception.getCause();
             if (throwable instanceof EventHubException) {
                 throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
-
-            throw new RuntimeException(exception);
         }
     }
 
@@ -348,9 +350,11 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             Throwable throwable = exception.getCause();
             if (throwable instanceof EventHubException) {
                 throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
-
-            throw new RuntimeException(exception);
         }
     }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.eventhubs;
 
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
 public interface IEventHubClient {
     void sendSync(EventData data)
@@ -16,7 +17,12 @@ public interface IEventHubClient {
     void sendSync(Iterable<EventData> eventDatas)
             throws EventHubException;
 
+    void sendSync(EventDataBatch eventDatas)
+        throws EventHubException, ExecutionException, InterruptedException;
+
     CompletableFuture<Void> send(Iterable<EventData> eventDatas);
+
+    CompletableFuture<Void> send(EventDataBatch eventDatas);
 
     void sendSync(EventData eventData, String partitionKey)
             throws EventHubException;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -6,7 +6,6 @@ package com.microsoft.azure.eventhubs;
 
 import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 public interface IEventHubClient {
     void sendSync(EventData data)
@@ -18,7 +17,7 @@ public interface IEventHubClient {
             throws EventHubException;
 
     void sendSync(EventDataBatch eventDatas)
-        throws EventHubException, ExecutionException, InterruptedException;
+        throws EventHubException;
 
     CompletableFuture<Void> send(Iterable<EventData> eventDatas);
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -96,16 +96,12 @@ public final class PartitionSender extends ClientEntity {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }
@@ -151,16 +147,12 @@ public final class PartitionSender extends ClientEntity {
             }
 
             Throwable throwable = exception.getCause();
-            if (throwable != null) {
-                if (throwable instanceof RuntimeException) {
-                    throw (RuntimeException) throwable;
-                }
-
-                if (throwable instanceof EventHubException) {
-                    throw (EventHubException) throwable;
-                }
-
-                throw new EventHubException(true, throwable);
+            if (throwable instanceof EventHubException) {
+                throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
         }
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -58,7 +58,7 @@ public final class PartitionSender extends ClientEntity {
      * BatchBuilder is used to create {@link EventDataBatch}es.
      * See {@link com.microsoft.azure.eventhubs.EventHubClient.BatchBuilder} for more info and code samples.
      *
-     * You cannot set a partitionKey in the EventDataBatch when using a partitionSender.
+     * You cannot set a partitionKey in the EventDataBatch when using a PartitionSender.
      */
     public class BatchBuilder {
         private final String partitionKey = null;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -232,9 +232,11 @@ public final class PartitionSender extends ClientEntity {
             Throwable throwable = exception.getCause();
             if (throwable instanceof EventHubException) {
                 throw (EventHubException) throwable;
+            } else if (throwable instanceof RuntimeException) {
+                throw (RuntimeException) throwable;
+            } else {
+                throw new RuntimeException(exception);
             }
-
-            throw new RuntimeException(exception);
         }
     }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -71,7 +71,8 @@ public final class PartitionSender extends ClientEntity {
         }
 
         if (options.maxMessageSize > maxSize) {
-            throw new IllegalArgumentException("The maxMessageSize set in BatchOptions is too large.");
+            throw new IllegalArgumentException("The maxMessageSize set in BatchOptions is too large. You set a maxMessageSize of " +
+                    options.maxMessageSize + ". The maximum allowed size is " + maxSize + ".");
         }
 
         return new EventDataBatch(options.maxMessageSize, null);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -16,20 +16,12 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import com.microsoft.azure.eventhubs.*;
 import junit.framework.AssertionFailedError;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.EventDataBatch;
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubException;
-import com.microsoft.azure.eventhubs.PartitionSender;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
 
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
@@ -51,7 +43,8 @@ public class EventDataBatchAPITest extends ApiTestBase {
     @Test
     public void sendSmallEventsFullBatchTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
-        final EventDataBatch batchEvents = sender.new BatchBuilder().createBatch();
+        BatchOptions options = new BatchOptions().withPartitionSenderDefaults();
+        final EventDataBatch batchEvents = sender.createBatch(options);
 
         while (batchEvents.tryAdd(new EventData("a".getBytes())));
 
@@ -62,9 +55,9 @@ public class EventDataBatchAPITest extends ApiTestBase {
     @Test
     public void sendSmallEventsFullBatchPartitionKeyTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
-        final EventDataBatch batchEvents = ehClient.new BatchBuilder()
-                .with(options -> options.partitionKey = UUID.randomUUID().toString())
-                .createBatch();
+        final BatchOptions options = new BatchOptions()
+                .with(o -> o.partitionKey = UUID.randomUUID().toString());
+        final EventDataBatch batchEvents = ehClient.createBatch(options);
 
         while (batchEvents.tryAdd(new EventData("a".getBytes())));
 
@@ -75,9 +68,9 @@ public class EventDataBatchAPITest extends ApiTestBase {
     public void sendBatchPartitionKeyValidateTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
         final String partitionKey = UUID.randomUUID().toString();
-        final EventDataBatch batchEvents = ehClient.new BatchBuilder()
-                .with( options -> options.partitionKey = partitionKey )
-                .createBatch();
+
+        final BatchOptions options = new BatchOptions().with( o -> o.partitionKey = partitionKey );
+        final EventDataBatch batchEvents = ehClient.createBatch(options);
 
         int count = 0;
         while (batchEvents.tryAdd(new EventData("a".getBytes())) && count++ < 10);
@@ -145,7 +138,8 @@ public class EventDataBatchAPITest extends ApiTestBase {
         receiver.setReceiveTimeout(Duration.ofSeconds(5));
 
         try {
-            final EventDataBatch batchEvents = sender.new BatchBuilder().createBatch();
+            final BatchOptions options = new BatchOptions().withPartitionSenderDefaults();
+            final EventDataBatch batchEvents = sender.createBatch(options);
 
             int count = 0;
             while (true) {
@@ -177,9 +171,8 @@ public class EventDataBatchAPITest extends ApiTestBase {
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
 
         final String partitionKey = UUID.randomUUID().toString();
-        final EventDataBatch batchEvents = ehClient.new BatchBuilder()
-                .with(options -> options.partitionKey = partitionKey)
-                .createBatch();
+        final BatchOptions options = new BatchOptions().with( o -> o.partitionKey = partitionKey);
+        final EventDataBatch batchEvents = ehClient.createBatch(options);
 
         int count = 0;
         while (true) {
@@ -201,9 +194,9 @@ public class EventDataBatchAPITest extends ApiTestBase {
     public void sendBatchWithPartitionKeyOnPartitionSenderTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
 
-        final EventDataBatch batchEvents = ehClient.new BatchBuilder()
-                .with(options -> options.partitionKey = UUID.randomUUID().toString())
-                .createBatch();
+
+        final BatchOptions options = new BatchOptions().with( o -> o.partitionKey = UUID.randomUUID().toString() );
+        final EventDataBatch batchEvents = sender.createBatch(options);
 
         int count = 0;
         while (true) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -43,7 +43,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
     @Test
     public void sendSmallEventsFullBatchTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
-        BatchOptions options = new BatchOptions().withPartitionSenderDefaults();
+        BatchOptions options = new BatchOptions();
         final EventDataBatch batchEvents = sender.createBatch(options);
 
         while (batchEvents.tryAdd(new EventData("a".getBytes())));
@@ -138,7 +138,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
         receiver.setReceiveTimeout(Duration.ofSeconds(5));
 
         try {
-            final BatchOptions options = new BatchOptions().withPartitionSenderDefaults();
+            final BatchOptions options = new BatchOptions();
             final EventDataBatch batchEvents = sender.createBatch(options);
 
             int count = 0;

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SasTokenReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SasTokenReceiveTest.java
@@ -31,19 +31,16 @@ public class SasTokenReceiveTest extends SasTokenTestBase {
     
     @Test()
     public void testReceiverStartOfStreamFilters() throws EventHubException {
-        
         receiveTest.testReceiverStartOfStreamFilters();
     }
     
     @After
     public void testCleanup() throws EventHubException {
-        
         receiveTest.testCleanup();
     }
     
     @AfterClass()
     public static void cleanup() throws EventHubException {
-        
         ReceiveTest.cleanup();
     }
 }


### PR DESCRIPTION
The following changes were made:

- EventDataBatch is no longer a subclass of Iterable<T>
- Exposed two new send APIs to send EventDataBatches from EventHubClient and PartitionSender
- Added BatchOptions class to make building EventDataBatches easier while avoiding many overloaded methods
- Updated EventDataBatch tests 