### PR TITLE
Switching from Java Logger to slf4j in EPH

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
@@ -33,7 +33,6 @@ import com.microsoft.azure.storage.blob.LeaseState;
 import com.microsoft.azure.storage.blob.ListBlobItem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.rmi.runtime.Log;
 
 
 class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseManager
@@ -637,7 +636,8 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     		{
 				lease.setOffset(cached.getOffset());
 				lease.setSequenceNumber(cached.getSequenceNumber());
-				TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), lease.getPartitionId(), "Replacing stale offset/seqno while uploading lease"));
+				TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), lease.getPartitionId(),
+                        "Replacing stale offset/seqno while uploading lease"));
 			}
 			else if (lease.getOffset() != null)
 			{
@@ -649,7 +649,8 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
  		blob.uploadText(jsonLease, null, condition, options, null);
 		// During create, we blindly try upload and it may throw. Doing the logging after the upload
 		// avoids a spurious trace in that case.
-        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), lease.getPartitionId(), "Raw JSON uploading for " + activity + ": " + jsonLease));
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), lease.getPartitionId(),
+                "Raw JSON uploading for " + activity + ": " + jsonLease));
     }
     
     private boolean wasLeaseLost(StorageException se, String partitionId)

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -5,12 +5,12 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import java.awt.*;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.logging.Level;
 
 import com.microsoft.azure.eventhubs.EventData;
 import com.microsoft.azure.eventhubs.EventHubClient;
@@ -19,6 +19,10 @@ import com.microsoft.azure.eventhubs.PartitionReceiver;
 import com.microsoft.azure.eventhubs.ReceiverOptions;
 import com.microsoft.azure.eventhubs.ReceiverDisconnectedException;
 import com.microsoft.azure.eventhubs.EventHubException;
+import com.sun.javafx.util.Logging;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sun.rmi.runtime.Log;
 
 class EventHubPartitionPump extends PartitionPump
 {
@@ -27,6 +31,8 @@ class EventHubPartitionPump extends PartitionPump
 	private EventHubClient eventHubClient = null;
 	private PartitionReceiver partitionReceiver = null;
     private InternalReceiveHandler internalReceiveHandler = null;
+
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(EventHubPartitionPump.class);
 
 	EventHubPartitionPump(EventProcessorHost host, Pump pump, Lease lease)
 	{
@@ -53,13 +59,13 @@ class EventHubPartitionPump extends PartitionPump
 	        	{
 	        		// TODO Assuming this is due to a receiver with a higher epoch.
 	        		// Is there a way to be sure without checking the exception text?
-	        		this.host.logWithHostAndPartition(Level.WARNING, this.partitionContext, "Receiver disconnected on create, bad epoch?", e);
+                    TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Receiver disconnected on create, bad epoch?"), e);
 	        		// If it's a bad epoch, then retrying isn't going to help.
 	        		break;
 	        	}
 	        	else
 	        	{
-					this.host.logWithHostAndPartition(Level.WARNING, this.partitionContext, "Failure creating client or receiver, retrying", e);
+					TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Failure creating client or receiver, retrying"), e);
 					retryCount++;
 	        	}
 			}
@@ -93,7 +99,7 @@ class EventHubPartitionPump extends PartitionPump
     private void openClients() throws EventHubException, IOException, InterruptedException, ExecutionException
     {
     	// Create new client
-    	this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Opening EH client");
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Opening EH client"));
 		this.internalOperationFuture = EventHubClient.createFromConnectionString(this.host.getEventHubConnectionString());
 		this.eventHubClient = (EventHubClient) this.internalOperationFuture.get();
 		this.internalOperationFuture = null;
@@ -103,7 +109,7 @@ class EventHubPartitionPump extends PartitionPump
         options.setReceiverRuntimeMetricEnabled(this.host.getEventProcessorOptions().getReceiverRuntimeMetricEnabled());
     	Object startAt = this.partitionContext.getInitialOffset();
     	long epoch = this.lease.getEpoch();
-    	this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Opening EH receiver with epoch " + epoch + " at location " + startAt);
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Opening EH receiver with epoch " + epoch + " at location " + startAt));
     	if (startAt instanceof String)
     	{
     		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(),
@@ -117,7 +123,7 @@ class EventHubPartitionPump extends PartitionPump
     	else
     	{
     		String errMsg = "Starting offset is not String or Instant, is " + ((startAt != null) ? startAt.getClass().toString() : "null");
-    		this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, errMsg);
+            TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, errMsg));
     		throw new RuntimeException(errMsg);
     	}
 		this.lease.setEpoch(epoch);
@@ -127,14 +133,14 @@ class EventHubPartitionPump extends PartitionPump
 		}
 		else
 		{
-			this.host.logWithHostAndPartition(Level.SEVERE, this.partitionContext, "createEpochReceiver failed with null");
+            TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "createEpochReceiver failed with null"));
 			throw new RuntimeException("createEpochReceiver failed with null");
 		}
 		this.partitionReceiver.setPrefetchCount(this.host.getEventProcessorOptions().getPrefetchCount());
 		this.partitionReceiver.setReceiveTimeout(this.host.getEventProcessorOptions().getReceiveTimeOut());
 		this.internalOperationFuture = null;
-		
-        this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "EH client and receiver creation finished");
+
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "EH client and receiver creation finished"));
     }
     
     private void cleanUpClients() // swallows all exceptions
@@ -145,7 +151,7 @@ class EventHubPartitionPump extends PartitionPump
 			// Fortunately this is idempotent -- setting the handler to null when it's already been
 			// nulled by code elsewhere is harmless!
 			// Setting to null also waits for the in-progress calls to complete
-			this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Setting receive handler to null");
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Setting receive handler to null"));
 			try
 			{
 				this.partitionReceiver.setReceiveHandler(null).get();
@@ -161,12 +167,12 @@ class EventHubPartitionPump extends PartitionPump
 				final Throwable throwable = exception.getCause();
 				if (throwable != null)
 				{
-					this.host.logWithHostAndPartition(Level.FINE, this.partitionContext,
-							"Got exception from onEvents when ReceiveHandler is set to null.", throwable);
+					TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+							"Got exception from onEvents when ReceiveHandler is set to null."), throwable);
 				}
 			}
 
-			this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Closing EH receiver");
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Closing EH receiver"));
         	final PartitionReceiver partitionReceiverTemp = this.partitionReceiver;
 			this.partitionReceiver = null;
 
@@ -176,17 +182,17 @@ class EventHubPartitionPump extends PartitionPump
 			}
 			catch (EventHubException exception)
 			{
-				this.host.logWithHostAndPartition(Level.FINE, this.partitionContext,"Closing EH receiver failed.", exception);
+                TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,"Closing EH receiver failed."), exception);
 			}
         }
         else
         {
-            this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "partitionReceiver is null in cleanup");
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "partitionReceiver is null in cleanup"));
         }
 
         if (this.eventHubClient != null)
 		{
-			this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "Closing EH client");
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Closing EH client"));
 			final EventHubClient eventHubClientTemp = this.eventHubClient;
 			this.eventHubClient = null;
 
@@ -196,12 +202,12 @@ class EventHubPartitionPump extends PartitionPump
 			}
 			catch (EventHubException exception)
 			{
-				this.host.logWithHostAndPartition(Level.FINE, this.partitionContext, "Closing EH client failed.", exception);
+				TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Closing EH client failed."), exception);
 			}
 		}
         else
         {
-            this.host.logWithHostAndPartition(Level.FINER, this.partitionContext, "eventHubClient is null in cleanup");
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "eventHubClient is null in cleanup"));
         }
     }
 
@@ -267,15 +273,18 @@ class EventHubPartitionPump extends PartitionPump
 			}
 			if (error instanceof ReceiverDisconnectedException)
 			{
-				EventHubPartitionPump.this.host.logWithHostAndPartition(Level.WARNING, EventHubPartitionPump.this.partitionContext,
-						"EventHub client disconnected, probably another host took the partition");
+				TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(EventHubPartitionPump.this.host.getHostName(),
+                        EventHubPartitionPump.this.partitionContext,
+						"EventHub client disconnected, probably another host took the partition"));
 			}
 			else
 			{
-				EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error: " + error.toString());
+                TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(EventHubPartitionPump.this.host.getHostName(),
+                        EventHubPartitionPump.this.partitionContext, "EventHub client error: " + error.toString()));
 				if (error instanceof Exception)
 				{
-					EventHubPartitionPump.this.host.logWithHostAndPartition(Level.SEVERE, EventHubPartitionPump.this.partitionContext, "EventHub client error continued", (Exception)error);
+					TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(EventHubPartitionPump.this.host.getHostName(),
+                            EventHubPartitionPump.this.partitionContext, "EventHub client error continued"), (Exception)error);
 				}
 			}
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -5,7 +5,6 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import java.awt.*;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -19,10 +18,8 @@ import com.microsoft.azure.eventhubs.PartitionReceiver;
 import com.microsoft.azure.eventhubs.ReceiverOptions;
 import com.microsoft.azure.eventhubs.ReceiverDisconnectedException;
 import com.microsoft.azure.eventhubs.EventHubException;
-import com.sun.javafx.util.Logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.rmi.runtime.Log;
 
 class EventHubPartitionPump extends PartitionPump
 {
@@ -59,13 +56,15 @@ class EventHubPartitionPump extends PartitionPump
 	        	{
 	        		// TODO Assuming this is due to a receiver with a higher epoch.
 	        		// Is there a way to be sure without checking the exception text?
-                    TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Receiver disconnected on create, bad epoch?"), e);
+                    TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                            "Receiver disconnected on create, bad epoch?"), e);
 	        		// If it's a bad epoch, then retrying isn't going to help.
 	        		break;
 	        	}
 	        	else
 	        	{
-					TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Failure creating client or receiver, retrying"), e);
+					TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                            "Failure creating client or receiver, retrying"), e);
 					retryCount++;
 	        	}
 			}
@@ -109,7 +108,8 @@ class EventHubPartitionPump extends PartitionPump
         options.setReceiverRuntimeMetricEnabled(this.host.getEventProcessorOptions().getReceiverRuntimeMetricEnabled());
     	Object startAt = this.partitionContext.getInitialOffset();
     	long epoch = this.lease.getEpoch();
-        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Opening EH receiver with epoch " + epoch + " at location " + startAt));
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                "Opening EH receiver with epoch " + epoch + " at location " + startAt));
     	if (startAt instanceof String)
     	{
     		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(),
@@ -133,14 +133,16 @@ class EventHubPartitionPump extends PartitionPump
 		}
 		else
 		{
-            TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "createEpochReceiver failed with null"));
+            TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                    "createEpochReceiver failed with null"));
 			throw new RuntimeException("createEpochReceiver failed with null");
 		}
 		this.partitionReceiver.setPrefetchCount(this.host.getEventProcessorOptions().getPrefetchCount());
 		this.partitionReceiver.setReceiveTimeout(this.host.getEventProcessorOptions().getReceiveTimeOut());
 		this.internalOperationFuture = null;
 
-        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "EH client and receiver creation finished"));
+        TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                "EH client and receiver creation finished"));
     }
     
     private void cleanUpClients() // swallows all exceptions
@@ -151,7 +153,8 @@ class EventHubPartitionPump extends PartitionPump
 			// Fortunately this is idempotent -- setting the handler to null when it's already been
 			// nulled by code elsewhere is harmless!
 			// Setting to null also waits for the in-progress calls to complete
-            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "Setting receive handler to null"));
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                    "Setting receive handler to null"));
 			try
 			{
 				this.partitionReceiver.setReceiveHandler(null).get();
@@ -182,12 +185,14 @@ class EventHubPartitionPump extends PartitionPump
 			}
 			catch (EventHubException exception)
 			{
-                TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,"Closing EH receiver failed."), exception);
+                TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                        "Closing EH receiver failed."), exception);
 			}
         }
         else
         {
-            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "partitionReceiver is null in cleanup"));
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                    "partitionReceiver is null in cleanup"));
         }
 
         if (this.eventHubClient != null)
@@ -207,7 +212,8 @@ class EventHubPartitionPump extends PartitionPump
 		}
         else
         {
-            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext, "eventHubClient is null in cleanup"));
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionContext,
+                    "eventHubClient is null in cleanup"));
         }
     }
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -493,7 +493,8 @@ public final class EventProcessorHost
     	
         if (this.executorService.isShutdown() || this.executorService.isTerminated())
     	{
-    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.hostName, "Calling registerEventProcessor/Factory after executor service has been shut down."));
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.hostName,
+                    "Calling registerEventProcessor/Factory after executor service has been shut down."));
     		throw new RejectedExecutionException("EventProcessorHost executor service has been shut down");
     	}
     	
@@ -582,48 +583,6 @@ public final class EventProcessorHost
     public static void forceExecutorShutdown(long secondsToWait) throws InterruptedException
     {
     }
-
-    
-    //
-    // Centralized logging.
-    //
-    /*
-    void log(Level logLevel, String logMessage)
-    {
-  		EventProcessorHost.TRACE_LOGGER.log(logLevel, logMessage);
-    	//System.out.println(LocalDateTime.now().toString() + ": " + logLevel.toString() + ": " + logMessage);
-    }
-    
-    void logWithHost(Level logLevel, String logMessage)
-    {
-    	log(logLevel, "host " + this.hostName + ": " + logMessage);
-    }
-    
-    void logWithHost(Level logLevel, String logMessage, Throwable e)
-    {
-    	logWithHost(logLevel, ExceptionUtil.toStackTraceString(e, logMessage));
-    }
-    
-    void logWithHostAndPartition(Level logLevel, String partitionId, String logMessage)
-    {
-    	logWithHost(logLevel, "partition " + partitionId + ": " + logMessage);
-    }
-    
-    void logWithHostAndPartition(Level logLevel, String partitionId, String logMessage, Throwable e)
-    {
-    	logWithHostAndPartition(logLevel, partitionId, ExceptionUtil.toStackTraceString(e, logMessage));
-    }
-    
-    void logWithHostAndPartition(Level logLevel, PartitionContext context, String logMessage)
-    {
-    	logWithHostAndPartition(logLevel, context.getPartitionId(), logMessage);
-    }
-    
-    void logWithHostAndPartition(Level logLevel, PartitionContext context, String logMessage, Throwable e)
-    {
-    	logWithHostAndPartition(logLevel, context.getPartitionId(), logMessage, e);
-    }
-    */
 
     /**
      * Convenience method for generating unique host names, safe to pass to the EventProcessorHost constructors

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -6,17 +6,15 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.ExceptionUtil;
-import com.microsoft.azure.eventhubs.StringUtil;
 import com.microsoft.azure.storage.StorageException;
 
 import java.net.URISyntaxException;
 import java.security.InvalidKeyException;
 import java.util.UUID;
 import java.util.concurrent.*;
-import java.util.logging.Logger;
-import java.util.logging.Level;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class EventProcessorHost
 {
@@ -38,9 +36,8 @@ public final class EventProcessorHost
     private final ExecutorService executorService;
     private final boolean weOwnExecutor;
     
-    public final static String EVENTPROCESSORHOST_TRACE = "eventprocessorhost.trace";
-	private static final Logger TRACE_LOGGER = Logger.getLogger(EventProcessorHost.EVENTPROCESSORHOST_TRACE);
-	
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(EventProcessorHost.class);
+
 	private static final Object uuidSynchronizer = new Object();
 
 	/**
@@ -358,8 +355,8 @@ public final class EventProcessorHost
         }
         
         this.partitionManager = new PartitionManager(this);
-        
-        logWithHost(Level.FINE, "New EventProcessorHost created");
+
+        TRACE_LOGGER.info(LoggingUtils.withHost(this.hostName, "New EventProcessorHost created."));
     }
 
     /**
@@ -496,7 +493,7 @@ public final class EventProcessorHost
     	
         if (this.executorService.isShutdown() || this.executorService.isTerminated())
     	{
-    		this.logWithHost(Level.SEVERE, "Calling registerEventProcessor/Factory after executor service has been shut down");
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.hostName, "Calling registerEventProcessor/Factory after executor service has been shut down."));
     		throw new RejectedExecutionException("EventProcessorHost executor service has been shut down");
     	}
     	
@@ -508,12 +505,13 @@ public final class EventProcessorHost
 			}
             catch (InvalidKeyException | URISyntaxException | StorageException e)
             {
-            	this.logWithHost(Level.SEVERE, "Failure initializing Storage lease manager", e);
+                TRACE_LOGGER.warn(LoggingUtils.withHost(this.hostName, "Failure initializing Storage lease manager."));
             	throw new RuntimeException("Failure initializing Storage lease manager", e);
 			}
         }
-        
-        logWithHost(Level.FINE, "Starting event processing");
+
+        TRACE_LOGGER.info(LoggingUtils.withHost(this.hostName, "Starting event processing."));
+
         this.processorFactory = factory;
         this.processorOptions = processorOptions;
         return this.executorService.submit(() -> this.partitionManager.initialize());
@@ -527,7 +525,7 @@ public final class EventProcessorHost
      */
     public void unregisterEventProcessor() throws InterruptedException, ExecutionException
     {
-    	logWithHost(Level.FINE, "Stopping event processing");
+    	TRACE_LOGGER.info(LoggingUtils.withHost(this.hostName, "Stopping event processing"));
         this.unregistered = true;
     	
     	if (this.partitionManager != null)
@@ -548,7 +546,7 @@ public final class EventProcessorHost
 	        catch (InterruptedException | ExecutionException e)
 	        {
 	        	// Log the failure but nothing really to do about it.
-	        	logWithHost(Level.SEVERE, "Failure shutting down", e);
+                TRACE_LOGGER.warn(LoggingUtils.withHost(this.hostName, "Failure shutting down"), e);
 	        	throw e;
 			}
     	}
@@ -589,7 +587,7 @@ public final class EventProcessorHost
     //
     // Centralized logging.
     //
-    
+    /*
     void log(Level logLevel, String logMessage)
     {
   		EventProcessorHost.TRACE_LOGGER.log(logLevel, logMessage);
@@ -625,6 +623,7 @@ public final class EventProcessorHost
     {
     	logWithHostAndPartition(logLevel, context.getPartitionId(), logMessage, e);
     }
+    */
 
     /**
      * Convenience method for generating unique host names, safe to pass to the EventProcessorHost constructors

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LoggingUtils.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LoggingUtils.java
@@ -1,0 +1,18 @@
+package com.microsoft.azure.eventprocessorhost;
+
+/**
+ * Centralize log message generation
+ */
+public final class LoggingUtils {
+    public static String withHost(String hostName, String logMessage) {
+        return "host " + hostName + ": " + logMessage;
+    }
+
+    public static String withHostAndPartition(String hostName, String partitionId, String logMessage) {
+        return "host " + hostName + ": " + partitionId + ": " + logMessage;
+    }
+
+    public static String withHostAndPartition(String hostName, PartitionContext context, String logMessage) {
+        return "host " + hostName + ": " + context.getPartitionId() + ": " + logMessage;
+    }
+}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LoggingUtils.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LoggingUtils.java
@@ -1,18 +1,23 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
 package com.microsoft.azure.eventprocessorhost;
 
 /**
  * Centralize log message generation
  */
 public final class LoggingUtils {
-    public static String withHost(String hostName, String logMessage) {
+    static String withHost(String hostName, String logMessage) {
         return "host " + hostName + ": " + logMessage;
     }
 
-    public static String withHostAndPartition(String hostName, String partitionId, String logMessage) {
+    static String withHostAndPartition(String hostName, String partitionId, String logMessage) {
         return "host " + hostName + ": " + partitionId + ": " + logMessage;
     }
 
-    public static String withHostAndPartition(String hostName, PartitionContext context, String logMessage) {
+    static String withHostAndPartition(String hostName, PartitionContext context, String logMessage) {
         return "host " + hostName + ": " + context.getPartitionId() + ": " + logMessage;
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -105,18 +105,21 @@ public class PartitionContext
     	{
     		// No checkpoint was ever stored. Use the initialOffsetProvider instead.
         	Function<String, Object> initialOffsetProvider = this.host.getEventProcessorOptions().getInitialOffsetProvider();
-    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId, "Calling user-provided initial offset provider"));
+    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId,
+                    "Calling user-provided initial offset provider"));
     		startAt = initialOffsetProvider.apply(this.partitionId);
     		if (startAt instanceof String)
     		{
     			this.offset = (String)startAt;
         		this.sequenceNumber = 0; // TODO we use sequenceNumber to check for regression of offset, 0 could be a problem until it gets updated from an event
-    	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId, "Initial offset provided: " + this.offset + "//" + this.sequenceNumber));
+    	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId,
+                        "Initial offset provided: " + this.offset + "//" + this.sequenceNumber));
     		}
     		else if (startAt instanceof Instant)
     		{
     			// can't set offset/sequenceNumber
-    	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId, "Initial timestamp provided: " + (Instant)startAt));
+    	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId,
+                        "Initial timestamp provided: " + (Instant)startAt));
     		}
     		else
     		{
@@ -129,7 +132,8 @@ public class PartitionContext
 	    	this.offset = startingCheckpoint.getOffset();
 	    	startAt = this.offset;
 	    	this.sequenceNumber = startingCheckpoint.getSequenceNumber();
-	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId, "Retrieved starting offset " + this.offset + "//" + this.sequenceNumber));
+	    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), this.partitionId,
+                    "Retrieved starting offset " + this.offset + "//" + this.sequenceNumber));
     	}
     	
     	return startAt;
@@ -169,8 +173,8 @@ public class PartitionContext
     
     private void persistCheckpoint(Checkpoint persistThis) throws IllegalArgumentException, InterruptedException, ExecutionException
     {
-    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), persistThis.getPartitionId(), "Saving checkpoint: " +
-    			persistThis.getOffset() + "//" + persistThis.getSequenceNumber()));
+    	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), persistThis.getPartitionId(),
+                "Saving checkpoint: " + persistThis.getOffset() + "//" + persistThis.getSequenceNumber()));
 		
         this.host.getCheckpointManager().updateCheckpoint(this.lease, persistThis).get();
     }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -113,12 +113,14 @@ class PartitionManager
     	}
     	catch (ExceptionWithAction e)
     	{
-    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Exception while initializing stores (" + e.getAction() + "), not starting partition manager"), e.getCause());
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                    "Exception while initializing stores (" + e.getAction() + "), not starting partition manager"), e.getCause());
     		throw e;
     	}
     	catch (Exception e)
     	{
-    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Exception while initializing stores, not starting partition manager"), e);
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                    "Exception while initializing stores, not starting partition manager"), e);
     		throw e;
     	}
     	
@@ -133,11 +135,13 @@ class PartitionManager
     	try
     	{
     		runLoop();
-    		TRACE_LOGGER.info(LoggingUtils.withHost(this.host.getHostName(), "Partition manager main loop exited normally, shutting down"));
+    		TRACE_LOGGER.info(LoggingUtils.withHost(this.host.getHostName(),
+                    "Partition manager main loop exited normally, shutting down"));
     	}
     	catch (ExceptionWithAction e)
     	{
-    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Exception from partition manager main loop, shutting down"), e.getCause());
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                    "Exception from partition manager main loop, shutting down"), e.getCause());
     		this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, e.getAction());
     	}
     	catch (Exception e)
@@ -158,7 +162,8 @@ class PartitionManager
         			this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), forLogging, EventProcessorHostActionStrings.PARTITION_MANAGER_MAIN_LOOP);
     			}
     		}
-    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Exception from partition manager main loop, shutting down"), e);
+    		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                    "Exception from partition manager main loop, shutting down"), e);
     		this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.PARTITION_MANAGER_MAIN_LOOP);
     	}
     	
@@ -358,18 +363,21 @@ class PartitionManager
 	            		{
     	                	if (leaseManager.acquireLease(stealee).get())
     	                	{
-    	                		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), stealee.getPartitionId(), "Stole lease"));
+    	                		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), stealee.getPartitionId(),
+                                        "Stole lease"));
     	                		allLeases.put(stealee.getPartitionId(), stealee);
     	                		ourLeasesCount++;
     	                	}
     	                	else
     	                	{
-    	                		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Failed to steal lease for partition " + stealee.getPartitionId()));
+    	                		TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                                        "Failed to steal lease for partition " + stealee.getPartitionId()));
     	                	}
 	            		}
 	            		catch (ExecutionException e)
 	            		{
-	            			TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(), "Exception stealing lease for partition " + stealee.getPartitionId()), e);
+	            			TRACE_LOGGER.warn(LoggingUtils.withHost(this.host.getHostName(),
+                                    "Exception stealing lease for partition " + stealee.getPartitionId()), e);
 	            			this.host.getEventProcessorOptions().notifyOfException(this.host.getHostName(), e, EventProcessorHostActionStrings.STEALING_LEASE,
 	            					stealee.getPartitionId());
 	            		}
@@ -381,7 +389,8 @@ class PartitionManager
             for (String partitionId : allLeases.keySet())
             {
             	Lease updatedLease = allLeases.get(partitionId);
-            	TRACE_LOGGER.info(LoggingUtils.withHost(this.host.getHostName(), "Lease on partition " + updatedLease.getPartitionId() + " owned by " + updatedLease.getOwner())); // DEBUG
+            	TRACE_LOGGER.debug(LoggingUtils.withHost(this.host.getHostName(),
+                        "Lease on partition " + updatedLease.getPartitionId() + " owned by " + updatedLease.getOwner())); // DEBUG
             	if (updatedLease.getOwner().compareTo(this.host.getHostName()) == 0)
             	{
             		this.pump.addPump(partitionId, updatedLease);
@@ -447,7 +456,8 @@ class PartitionManager
     			if (l.getOwner().compareTo(biggestOwner) == 0)
     			{
     				stealTheseLeases.add(l);
-    				TRACE_LOGGER.info(LoggingUtils.withHost(this.host.getHostName(), "Proposed to steal lease for partition " + l.getPartitionId() + " from " + biggestOwner));
+    				TRACE_LOGGER.info(LoggingUtils.withHost(this.host.getHostName(),
+                            "Proposed to steal lease for partition " + l.getPartitionId() + " from " + biggestOwner));
   					break;
     			}
     		}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -87,7 +87,8 @@ class Pump
     	PartitionPump capturedPump = this.pumpStates.get(partitionId);
     	if (capturedPump != null)
     	{
-            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "closing pump for reason " + reason.toString()));
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "closing pump for reason " + reason.toString()));
 			retval = this.host.getExecutorService().submit(() -> capturedPump.shutdown(reason));
 
     		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "removing pump"));
@@ -97,7 +98,8 @@ class Pump
     	{
     		// PartitionManager main loop tries to remove pump for every partition that the host does not own, just to be sure.
     		// Not finding a pump for a partition is normal and expected most of the time.
-    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "no pump found to remove for partition " + partitionId));
+    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "no pump found to remove for partition " + partitionId));
     	}
     	return retval;
     }
@@ -113,7 +115,8 @@ class Pump
 			}
 			catch (InterruptedException | ExecutionException e)
 			{
-				TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "error while shutting down failed partition pump"), e);
+				TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                        "error while shutting down failed partition pump"), e);
 			}
     	}
     }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Pump.java
@@ -5,12 +5,14 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
 
 
 class Pump
@@ -18,6 +20,8 @@ class Pump
     protected final EventProcessorHost host; // protected for testability
 
     private ConcurrentHashMap<String, PartitionPump> pumpStates;
+
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(Pump.class);
     
     public Pump(EventProcessorHost host)
     {
@@ -45,7 +49,7 @@ class Pump
     		else
     		{
     			// Pump is working, just replace the lease.
-    			this.host.logWithHostAndPartition(Level.FINER, partitionId, "updating lease for pump");
+    			TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "updating lease for pump"));
     			capturedPump.setLease(lease);
     		}
     	}
@@ -70,7 +74,7 @@ class Pump
 					if (newPartitionPump.getPumpStatus() == PartitionPumpStatus.PP_RUNNING)
 					{
 						Pump.this.pumpStates.put(partitionId, newPartitionPump); // do the put after start, if the start fails then put doesn't happen
-						Pump.this.host.logWithHostAndPartition(Level.FINE, partitionId, "created new pump");
+						TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(Pump.this.host.getHostName(), partitionId, "created new pump"));
 					}
 					return null;
 				}
@@ -83,17 +87,17 @@ class Pump
     	PartitionPump capturedPump = this.pumpStates.get(partitionId);
     	if (capturedPump != null)
     	{
-			this.host.logWithHostAndPartition(Level.FINE, partitionId, "closing pump for reason " + reason.toString());
+            TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "closing pump for reason " + reason.toString()));
 			retval = this.host.getExecutorService().submit(() -> capturedPump.shutdown(reason));
-    		
-    		this.host.logWithHostAndPartition(Level.FINE, partitionId, "removing pump");
+
+    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "removing pump"));
     		this.pumpStates.remove(partitionId);
     	}
     	else
     	{
     		// PartitionManager main loop tries to remove pump for every partition that the host does not own, just to be sure.
     		// Not finding a pump for a partition is normal and expected most of the time.
-    		this.host.logWithHostAndPartition(Level.FINER, partitionId, "no pump found to remove for partition " + partitionId);
+    		TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "no pump found to remove for partition " + partitionId));
     	}
     	return retval;
     }
@@ -109,7 +113,7 @@ class Pump
 			}
 			catch (InterruptedException | ExecutionException e)
 			{
-				this.host.logWithHostAndPartition(Level.WARNING, partitionId, "error while shutting down failed partition pump", e);
+				TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "error while shutting down failed partition pump"), e);
 			}
     	}
     }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
@@ -5,11 +5,13 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.logging.Level;
 
 
 //
@@ -30,6 +32,8 @@ public class InMemoryCheckpointManager implements ICheckpointManager
 {
     private EventProcessorHost host;
     private ExecutorService executor;
+
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(InMemoryCheckpointManager.class);
 
     public InMemoryCheckpointManager()
     {
@@ -90,7 +94,7 @@ public class InMemoryCheckpointManager implements ICheckpointManager
         Checkpoint checkpointInStore = InMemoryCheckpointStore.singleton.getCheckpoint(partitionId);
         if (checkpointInStore == null)
         {
-        	this.host.logWithHostAndPartition(Level.SEVERE, partitionId, "getCheckpoint() no existing Checkpoint");
+        	TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "getCheckpoint() no existing Checkpoint"));
         	returnCheckpoint = null;
         }
         else if (checkpointInStore.getSequenceNumber() == -1)
@@ -117,7 +121,8 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     	Checkpoint returnCheckpoint = null;
     	if (checkpointInStore != null)
     	{
-        	this.host.logWithHostAndPartition(Level.INFO, partitionId, "createCheckpointIfNotExists() found existing checkpoint, OK");
+        	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "createCheckpointIfNotExists() found existing checkpoint, OK"));
         	if (checkpointInStore.getSequenceNumber() != -1)
         	{
         		returnCheckpoint = new Checkpoint(checkpointInStore);
@@ -130,7 +135,8 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     	}
     	else
     	{
-        	this.host.logWithHostAndPartition(Level.INFO, partitionId, "createCheckpointIfNotExists() creating new checkpoint");
+        	TRACE_LOGGER.info(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "createCheckpointIfNotExists() creating new checkpoint"));
         	Checkpoint newStoreCheckpoint = new Checkpoint(partitionId);
         	newStoreCheckpoint.setOffset(null);
         	newStoreCheckpoint.setSequenceNumber(-1);
@@ -167,7 +173,8 @@ public class InMemoryCheckpointManager implements ICheckpointManager
     	}
     	else
     	{
-    		this.host.logWithHostAndPartition(Level.SEVERE, partitionId, "updateCheckpoint() can't find checkpoint");
+    		TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "updateCheckpoint() can't find checkpoint"));
     	}
     	return null;
     }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
@@ -94,7 +94,8 @@ public class InMemoryCheckpointManager implements ICheckpointManager
         Checkpoint checkpointInStore = InMemoryCheckpointStore.singleton.getCheckpoint(partitionId);
         if (checkpointInStore == null)
         {
-        	TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId, "getCheckpoint() no existing Checkpoint"));
+        	TRACE_LOGGER.warn(LoggingUtils.withHostAndPartition(this.host.getHostName(), partitionId,
+                    "getCheckpoint() no existing Checkpoint"));
         	returnCheckpoint = null;
         }
         else if (checkpointInStore.getSequenceNumber() == -1)


### PR DESCRIPTION
This just swaps all java logging with slf4j.

The java logging was centralized within EventProcessorHost.java. To stick to slf4j conventions, I 'de-centralized' the logging by creating a Logger within each .java file. 