### PR TITLE
Add optional user agent static variable

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -29,6 +29,11 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     private volatile boolean isSenderCreateStarted;
     public static final String DEFAULT_CONSUMER_GROUP_NAME = "$Default";
 
+    /**
+     * It will be truncated to 256 characters
+     */
+    public static String userAgent = null;
+
     private final String eventHubName;
     private final Object senderCreateSync;
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/AmqpConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/AmqpConstants.java
@@ -54,6 +54,8 @@ public final class AmqpConstants {
     public static final Symbol VERSION = Symbol.valueOf("version");
     public static final Symbol PLATFORM = Symbol.valueOf("platform");
     public static final Symbol FRAMEWORK = Symbol.valueOf("framework");
+    public static final Symbol USER_AGENT = Symbol.valueOf("user-agent");
+    public static final int MAX_USER_AGENT_LENGTH = 256;
 
     public static final int AMQP_BATCH_MESSAGE_FORMAT = 0x80013700; // 2147563264L;
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/amqp/ConnectionHandler.java
@@ -7,6 +7,7 @@ package com.microsoft.azure.eventhubs.amqp;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.microsoft.azure.eventhubs.EventHubClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,11 @@ public final class ConnectionHandler extends BaseHandler {
         connectionProperties.put(AmqpConstants.VERSION, ClientConstants.CURRENT_JAVACLIENT_VERSION);
         connectionProperties.put(AmqpConstants.PLATFORM, ClientConstants.PLATFORM_INFO);
         connectionProperties.put(AmqpConstants.FRAMEWORK, ClientConstants.FRAMEWORK_INFO);
+        if (EventHubClient.userAgent != null) {
+            connectionProperties.put(AmqpConstants.USER_AGENT, EventHubClient.userAgent.length() < AmqpConstants.MAX_USER_AGENT_LENGTH ?
+                    EventHubClient.userAgent :
+                    EventHubClient.userAgent.substring(0, AmqpConstants.MAX_USER_AGENT_LENGTH));
+        }
         connection.setProperties(connectionProperties);
 
         connection.open();


### PR DESCRIPTION
## Description
Added userAgent - a public static variable that, if set, will get propagates along with the rest of the connection properties.
Unfortunetly this is static because the properties are being sent while the EventHubClient is being constructed.
<!--
Please add an informative description that covers the changes made by the pull request.

If applicable, reference the bug/issue that this pull request fixes here.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.