### PR TITLE
getRuntime method check that EventHubClient is not closed

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -1283,8 +1283,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() throws EventHubException {
     	CompletableFuture<EventHubRuntimeInformation> future1 = null;
     	
-    	if (this.underlyingFactory.getIsClosingOrClosed())
-    	{
+    	if (this.underlyingFactory.getIsClosingOrClosed()) {
     		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
     	}
 
@@ -1326,8 +1325,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) throws EventHubException {
     	CompletableFuture<EventHubPartitionRuntimeInformation> future1 = null;
     	
-    	if (this.underlyingFactory.getIsClosingOrClosed())
-    	{
+    	if (this.underlyingFactory.getIsClosingOrClosed()) {
     		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
     	}
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -1275,12 +1275,19 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * Retries until it reaches the operation timeout, then either rethrows the last error if available or
      * returns null to indicate timeout.
      * 
-     * @return CompletableFuture which returns an EventHubRuntimeInformation on success, or null on timeout.  
+     * @return CompletableFuture which returns an EventHubRuntimeInformation on success, or null on timeout.
+     *
+     * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
-    public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() {
+    public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() throws EventHubException {
     	CompletableFuture<EventHubRuntimeInformation> future1 = null;
     	
+    	if (this.underlyingFactory.getIsClosingOrClosed())
+    	{
+    		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
+    	}
+
     	Map<String, String> request = new HashMap<String, String>();
         request.put(ClientConstants.MANAGEMENT_ENTITY_TYPE_KEY, ClientConstants.MANAGEMENT_EVENTHUB_ENTITY_TYPE);
         request.put(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY, this.eventHubName);
@@ -1312,11 +1319,18 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * 
      * @param partitionId  Partition to get information about. Must be one of the partition ids returned by getRuntimeInformation.
      * @return CompletableFuture which returns an EventHubPartitionRuntimeInformation on success, or null on timeout.  
+     *
+     * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
-    public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) {
+    public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) throws EventHubException {
     	CompletableFuture<EventHubPartitionRuntimeInformation> future1 = null;
     	
+    	if (this.underlyingFactory.getIsClosingOrClosed())
+    	{
+    		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
+    	}
+
     	Map<String, String> request = new HashMap<String, String>();
         request.put(ClientConstants.MANAGEMENT_ENTITY_TYPE_KEY, ClientConstants.MANAGEMENT_PARTITION_ENTITY_TYPE);
         request.put(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY, this.eventHubName);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -1280,12 +1280,10 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
-    public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() throws EventHubException {
+    public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() {
     	CompletableFuture<EventHubRuntimeInformation> future1 = null;
     	
-    	if (this.underlyingFactory.getIsClosingOrClosed()) {
-    		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
-    	}
+    	throwIfClosed();
 
     	Map<String, String> request = new HashMap<String, String>();
         request.put(ClientConstants.MANAGEMENT_ENTITY_TYPE_KEY, ClientConstants.MANAGEMENT_EVENTHUB_ENTITY_TYPE);
@@ -1322,12 +1320,10 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
-    public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) throws EventHubException {
+    public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) {
     	CompletableFuture<EventHubPartitionRuntimeInformation> future1 = null;
     	
-    	if (this.underlyingFactory.getIsClosingOrClosed()) {
-    		throw new EventHubException(false, "Cannot perform operations on closed EventHubClient");
-    	}
+    	throwIfClosed();
 
     	Map<String, String> request = new HashMap<String, String>();
         request.put(ClientConstants.MANAGEMENT_ENTITY_TYPE_KEY, ClientConstants.MANAGEMENT_PARTITION_ENTITY_TYPE);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -1276,8 +1276,6 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * returns null to indicate timeout.
      * 
      * @return CompletableFuture which returns an EventHubRuntimeInformation on success, or null on timeout.
-     *
-     * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
     public CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() {
@@ -1316,8 +1314,6 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * 
      * @param partitionId  Partition to get information about. Must be one of the partition ids returned by getRuntimeInformation.
      * @return CompletableFuture which returns an EventHubPartitionRuntimeInformation on success, or null on timeout.  
-     *
-     * @throws EventHubException if the EventHubClient is closed or closing.
      */
     @Override
     public CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -113,7 +113,7 @@ public interface IEventHubClient {
 
     CompletableFuture<Void> onClose();
 
-    CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() throws EventHubException;
+    CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation();
 
-    CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) throws EventHubException;
+    CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId);
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -113,7 +113,7 @@ public interface IEventHubClient {
 
     CompletableFuture<Void> onClose();
 
-    CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation();
+    CompletableFuture<EventHubRuntimeInformation> getRuntimeInformation() throws EventHubException;
 
-    CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId);
+    CompletableFuture<EventHubPartitionRuntimeInformation> getPartitionRuntimeInformation(String partitionId) throws EventHubException;
 }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -344,6 +344,7 @@ public class RequestResponseTest  extends ApiTestBase {
 
     	try {
     		ehc.getRuntimeInformation().get();
+    		Assert.fail("getRuntimeInformation did not throw as expected");
     	}
     	catch (IllegalStateException e) {
     		// Success
@@ -354,6 +355,7 @@ public class RequestResponseTest  extends ApiTestBase {
 
     	try {
     		ehc.getPartitionRuntimeInformation("0").get();
+    		Assert.fail("getPartitionRuntimeInformation did not throw as expected");
     	}
     	catch (IllegalStateException e) {
     		// Success

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -337,6 +337,32 @@ public class RequestResponseTest  extends ApiTestBase {
     	ehc.closeSync();
     }
     
+    @Test
+    public void testGetRuntimesClosedClient() throws EventHubException, IOException, InterruptedException, ExecutionException {
+    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(connectionString.toString());
+    	ehc.closeSync();
+
+    	try {
+    		ehc.getRuntimeInformation().get();
+    	}
+    	catch (EventHubException e) {
+    		// Success
+    	}
+    	catch (Exception e) {
+    		Assert.fail("Unexpected exception from getRuntimeInformation " + e.toString());
+    	}
+
+    	try {
+    		ehc.getPartitionRuntimeInformation("0").get();
+    	}
+    	catch (EventHubException e) {
+    		// Success
+    	}
+    	catch (Exception e) {
+    		Assert.fail("Unexpected exception from getPartitionRuntimeInformation " + e.toString());
+    	}
+    }
+
     @AfterClass()
     public static void cleanup() throws EventHubException {
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -345,7 +345,7 @@ public class RequestResponseTest  extends ApiTestBase {
     	try {
     		ehc.getRuntimeInformation().get();
     	}
-    	catch (EventHubException e) {
+    	catch (IllegalStateException e) {
     		// Success
     	}
     	catch (Exception e) {
@@ -355,7 +355,7 @@ public class RequestResponseTest  extends ApiTestBase {
     	try {
     		ehc.getPartitionRuntimeInformation("0").get();
     	}
-    	catch (EventHubException e) {
+    	catch (IllegalStateException e) {
     		// Success
     	}
     	catch (Exception e) {


### PR DESCRIPTION
## Description
getRuntime* methods check that the EventHubClient is not closed or closing. Without this check, the user gets a mysterious RejectedExecutionException from the threadpool in Timer because the method tries to schedule a thread in that pool when it has already been shut down.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.