### PR TITLE
Asyncfix: use async variants of completableFuture.then* methods to make sure tasks are scheduled on a thread pool

### DIFF
--- a/azure-eventhubs-eph/pom.xml
+++ b/azure-eventhubs-eph/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-storage</artifactId>
-        <version>5.3.1</version>
+        <version>5.5.0</version>
     </dependency>
     <dependency>
 	   	<groupId>com.google.code.gson</groupId>

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -123,7 +123,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
         final EventHubClient eventHubClient = new EventHubClient(connStr);
 
         return MessagingFactory.createFromConnectionString(connectionString.toString(), retryPolicy)
-                .thenApply(new Function<MessagingFactory, EventHubClient>() {
+                .thenApplyAsync(new Function<MessagingFactory, EventHubClient>() {
                     @Override
                     public EventHubClient apply(MessagingFactory factory) {
                         eventHubClient.underlyingFactory = factory;
@@ -141,7 +141,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      */
     public final EventDataBatch createBatch(BatchOptions options) throws EventHubException {
         try {
-            int maxSize = this.createInternalSender().thenApply((aVoid) -> this.sender.getMaxMessageSize()).get();
+            int maxSize = this.createInternalSender().thenApplyAsync((aVoid) -> this.sender.getMaxMessageSize()).get();
             if (options.maxMessageSize == null) {
                 return new EventDataBatch(maxSize, options.partitionKey);
             }
@@ -239,7 +239,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             throw new IllegalArgumentException("EventData cannot be empty.");
         }
 
-        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(data.toAmqpMessage());
@@ -323,7 +323,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             throw new IllegalArgumentException("Empty batch of EventData cannot be sent.");
         }
 
-        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas));
@@ -442,7 +442,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             throw new IllegalArgumentException("partitionKey cannot be null");
         }
 
-        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(eventData.toAmqpMessage(partitionKey));
@@ -512,7 +512,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
                     String.format(Locale.US, "PartitionKey exceeds the maximum allowed length of partitionKey: {0}", ClientConstants.MAX_PARTITION_KEY_LENGTH));
         }
 
-        return this.createInternalSender().thenCompose(new Function<Void, CompletableFuture<Void>>() {
+        return this.createInternalSender().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
             @Override
             public CompletableFuture<Void> apply(Void voidArg) {
                 return EventHubClient.this.sender.send(EventDataUtil.toAmqpMessages(eventDatas, partitionKey));
@@ -1236,7 +1236,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
         if (this.underlyingFactory != null) {
             synchronized (this.senderCreateSync) {
                 final CompletableFuture<Void> internalSenderClose = this.sender != null
-                        ? this.sender.close().thenCompose(new Function<Void, CompletableFuture<Void>>() {
+                        ? this.sender.close().thenComposeAsync(new Function<Void, CompletableFuture<Void>>() {
                     @Override
                     public CompletableFuture<Void> apply(Void voidArg) {
                         return EventHubClient.this.underlyingFactory.close();
@@ -1256,7 +1256,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             synchronized (this.senderCreateSync) {
                 if (!this.isSenderCreateStarted) {
                     this.createSender = MessageSender.create(this.underlyingFactory, StringUtil.getRandomString(), this.eventHubName)
-                            .thenAccept(new Consumer<MessageSender>() {
+                            .thenAcceptAsync(new Consumer<MessageSender>() {
                                 public void accept(MessageSender a) {
                                     EventHubClient.this.sender = a;
                                 }
@@ -1290,7 +1290,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
         future1 = this.<EventHubRuntimeInformation>addManagementToken(request);
 
         if (future1 == null) {
-	        future1 = managementWithRetry(request).thenCompose(new Function<Map<String, Object>, CompletableFuture<EventHubRuntimeInformation>>() {
+	        future1 = managementWithRetry(request).thenComposeAsync(new Function<Map<String, Object>, CompletableFuture<EventHubRuntimeInformation>>() {
 				@Override
 				public CompletableFuture<EventHubRuntimeInformation> apply(Map<String, Object> rawdata) {
 			        CompletableFuture<EventHubRuntimeInformation> future2 = new CompletableFuture<EventHubRuntimeInformation>();
@@ -1329,7 +1329,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
         future1 = this.<EventHubPartitionRuntimeInformation>addManagementToken(request);
 
         if (future1 == null) {
-	        future1 = managementWithRetry(request).thenCompose(new Function<Map<String, Object>, CompletableFuture<EventHubPartitionRuntimeInformation>>() {
+	        future1 = managementWithRetry(request).thenComposeAsync(new Function<Map<String, Object>, CompletableFuture<EventHubPartitionRuntimeInformation>>() {
 				@Override
 				public CompletableFuture<EventHubPartitionRuntimeInformation> apply(Map<String, Object> rawdata) {
 					CompletableFuture<EventHubPartitionRuntimeInformation> future2 = new CompletableFuture<EventHubPartitionRuntimeInformation>();

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/MessagingFactory.java
@@ -87,7 +87,7 @@ public class MessagingFactory extends ClientEntity implements IAmqpConnection, I
                 : new SharedAccessSignatureTokenProvider(builder.getSharedAccessSignature());
 
         this.closeTask = new CompletableFuture<>();
-        this.closeTask.thenAccept(new Consumer<Void>() {
+        this.closeTask.thenAcceptAsync(new Consumer<Void>() {
             @Override
             public void accept(Void arg0) {
                 Timer.unregister(getClientId());

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -125,7 +125,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
         }
 
         final PartitionReceiver receiver = new PartitionReceiver(factory, eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, dateTime, epoch, isEpochReceiver, receiverOptions);
-        return receiver.createInternalReceiver().thenApply(new Function<Void, PartitionReceiver>() {
+        return receiver.createInternalReceiver().thenApplyAsync(new Function<Void, PartitionReceiver>() {
             public PartitionReceiver apply(Void a) {
                 return receiver;
             }
@@ -137,7 +137,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
                 StringUtil.getRandomString(),
                 String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId),
                 PartitionReceiver.DEFAULT_PREFETCH_COUNT, this)
-                .thenAccept(new Consumer<MessageReceiver>() {
+                .thenAcceptAsync(new Consumer<MessageReceiver>() {
                     public void accept(MessageReceiver r) {
                         PartitionReceiver.this.internalReceiver = r;
                     }
@@ -289,7 +289,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
      * @return A completableFuture that will yield a batch of {@link EventData}'s from the partition on which this receiver is created. Returns 'null' if no {@link EventData} is present.
      */
     public CompletableFuture<Iterable<EventData>> receive(final int maxEventCount) {
-        return this.internalReceiver.receive(maxEventCount).thenApply(new Function<Collection<Message>, Iterable<EventData>>() {
+        return this.internalReceiver.receive(maxEventCount).thenApplyAsync(new Function<Collection<Message>, Iterable<EventData>>() {
             @Override
             public Iterable<EventData> apply(Collection<Message> amqpMessages) {
                 PassByRef<Message> lastMessageRef = null;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -37,7 +37,7 @@ public final class PartitionSender extends ClientEntity {
     static CompletableFuture<PartitionSender> Create(MessagingFactory factory, String eventHubName, String partitionId) throws EventHubException {
         final PartitionSender sender = new PartitionSender(factory, eventHubName, partitionId);
         return sender.createInternalSender()
-                .thenApply(new Function<Void, PartitionSender>() {
+                .thenApplyAsync(new Function<Void, PartitionSender>() {
                     public PartitionSender apply(Void a) {
                         return sender;
                     }
@@ -47,7 +47,7 @@ public final class PartitionSender extends ClientEntity {
     private CompletableFuture<Void> createInternalSender() throws EventHubException {
         return MessageSender.create(this.factory, StringUtil.getRandomString(),
                 String.format("%s/Partitions/%s", this.eventHubName, this.partitionId))
-                .thenAccept(new Consumer<MessageSender>() {
+                .thenAcceptAsync(new Consumer<MessageSender>() {
                     public void accept(MessageSender a) {
                         PartitionSender.this.internalSender = a;
                     }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -4,7 +4,9 @@
  */
 package com.microsoft.azure.eventhubs.sendrecv;
 
+import java.nio.charset.Charset;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Random;

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<url>https://github.com/Azure/azure-event-hubs</url>
 	
 	<properties>
-		<proton-j-version>0.19.0</proton-j-version>
+		<proton-j-version>0.22.0</proton-j-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.8.0-alpha2</slf4j-version>
 	</properties>


### PR DESCRIPTION
fix issue #100 
Thanks to @nkgami for identifying the issue. 