### PR TITLE
Changed access modifiers for some classes for easier mocking

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ClientEntity.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ClientEntity.java
@@ -35,7 +35,7 @@ public abstract class ClientEntity {
         return this.clientId;
     }
 
-    boolean getIsClosed() {
+    public boolean getIsClosed() {
         final boolean isParentClosed = this.parent != null && this.parent.getIsClosed();
         synchronized (this.syncClose) {
             return isParentClosed || this.isClosed;
@@ -43,7 +43,7 @@ public abstract class ClientEntity {
     }
 
     // returns true even if the Parent is (being) Closed
-    boolean getIsClosingOrClosed() {
+    public boolean getIsClosingOrClosed() {
         final boolean isParentClosingOrClosed = this.parent != null && this.parent.getIsClosingOrClosed();
         synchronized (this.syncClose) {
             return isParentClosingOrClosed || this.isClosing || this.isClosed;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubPartitionRuntimeInformation.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubPartitionRuntimeInformation.java
@@ -15,7 +15,7 @@ final public class EventHubPartitionRuntimeInformation {
     private final String lastEnqueuedOffset;
     private final Instant lastEnqueuedTimeUtc;
 
-    EventHubPartitionRuntimeInformation(
+    public EventHubPartitionRuntimeInformation(
             final String eventHubPath,
             final String partitionId,
             final long beginSequenceNumber,

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubRuntimeInformation.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubRuntimeInformation.java
@@ -13,7 +13,7 @@ final public class EventHubRuntimeInformation {
     final int partitionCount;
     final String[] partitionIds;
 
-    EventHubRuntimeInformation(final String path, final Instant createdAt, final int partitionCount, final String[] partitionIds) {
+    public EventHubRuntimeInformation(final String path, final Instant createdAt, final int partitionCount, final String[] partitionIds) {
         this.path = path;
         this.createdAt = createdAt;
         this.partitionCount = partitionCount;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -40,7 +40,7 @@ import com.microsoft.azure.eventhubs.amqp.AmqpConstants;
  * @see EventHubClient#createReceiver
  * @see EventHubClient#createEpochReceiver
  */
-public final class PartitionReceiver extends ClientEntity implements IReceiverSettingsProvider {
+public class PartitionReceiver extends ClientEntity implements IReceiverSettingsProvider {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionReceiver.class);
     private static final int MINIMUM_PREFETCH_COUNT = 10;
     private static final int MAXIMUM_PREFETCH_COUNT = 999;
@@ -76,7 +76,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
     private ReceiverOptions receiverOptions;
     private ReceiverRuntimeInformation runtimeInformation;
 
-    private PartitionReceiver(MessagingFactory factory,
+    protected PartitionReceiver(MessagingFactory factory,
                               final String eventHubName,
                               final String consumerGroupName,
                               final String partitionId,

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -16,14 +16,14 @@ import java.util.function.Function;
  * @see EventHubClient#createPartitionSender(String)
  * @see EventHubClient#createFromConnectionString(String)
  */
-public final class PartitionSender extends ClientEntity {
+public class PartitionSender extends ClientEntity {
     private final String partitionId;
     private final String eventHubName;
     private final MessagingFactory factory;
 
     private MessageSender internalSender;
 
-    private PartitionSender(MessagingFactory factory, String eventHubName, String partitionId) {
+    protected PartitionSender(MessagingFactory factory, String eventHubName, String partitionId) {
         super(null, null);
 
         this.partitionId = partitionId;


### PR DESCRIPTION
As stated in 
https://github.com/Azure/azure-event-hubs-java/issues/169

Do note that I haven't created IPartitionSender and IPartitionReceiver at the moment.
This can at least save me the trouble of using reflection to create some of these objects.