### PR TITLE
fixing bug when creating default EventDataBatches

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/BatchOptions.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/BatchOptions.java
@@ -32,8 +32,7 @@ import java.util.function.Consumer;
  *     however, you can NOT set a partition key when using PartitionSender
  *
  *     // Create EventDataBatch with defaults
- *     BatchOptions options = new BatchOptions()
- *     EventDataBatch edb1 = client.createBatch(options);
+ *     EventDataBatch edb1 = client.createBatch();
  *
  *     // Create EventDataBatch with custom partitionKey
  *     BatchOptions options = new BatchOptions().with( options -> options.partitionKey = "foo");

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -171,12 +171,13 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 
     /**
      * Creates an Empty Collection of {@link EventData}.
+     * The same partitionKey must be used while sending these events using {@link EventHubClient#send(EventDataBatch)}.
      *
      * @return the empty {@link EventDataBatch}, after negotiating maximum message size with EventHubs service
      * @throws EventHubException if the Microsoft Azure Event Hubs service encountered problems during the operation.
      */
     public final EventDataBatch createBatch() throws EventHubException {
-        return this.createBatch(null);
+        return this.createBatch(new BatchOptions());
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -56,6 +56,8 @@ public final class PartitionSender extends ClientEntity {
 
     /**
      * Creates an Empty Collection of {@link EventData}.
+     * The same partitionKey must be used while sending these events using {@link PartitionSender#send(EventDataBatch)}.
+     *
      * @return the empty {@link EventDataBatch}, after negotiating maximum message size with EventHubs service
      */
     public EventDataBatch createBatch(BatchOptions options) {
@@ -76,6 +78,16 @@ public final class PartitionSender extends ClientEntity {
         }
 
         return new EventDataBatch(options.maxMessageSize, null);
+    }
+
+    /**
+     * Creates an Empty Collection of {@link EventData}.
+     * The same partitionKey must be used while sending these events using {@link PartitionSender#send(EventDataBatch)}.
+     *
+     * @return the empty {@link EventDataBatch}, after negotiating maximum message size with EventHubs service
+     */
+    public final EventDataBatch createBatch() {
+        return this.createBatch(new BatchOptions());
     }
 
     /**

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -45,8 +45,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
     @Test
     public void sendSmallEventsFullBatchTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
-        BatchOptions options = new BatchOptions();
-        final EventDataBatch batchEvents = sender.createBatch(options);
+        final EventDataBatch batchEvents = sender.createBatch();
 
         while (batchEvents.tryAdd(new EventData("a".getBytes())));
 
@@ -140,8 +139,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
         receiver.setReceiveTimeout(Duration.ofSeconds(5));
 
         try {
-            final BatchOptions options = new BatchOptions();
-            final EventDataBatch batchEvents = sender.createBatch(options);
+            final EventDataBatch batchEvents = sender.createBatch();
 
             int count = 0;
             while (true) {


### PR DESCRIPTION
There's a NullPointerException when calling createBatch(). This change makes sure calling createBatch() returns a default batch. 