### PR TITLE
Converting AmqpException to EventHubException before retry is attempted in EventHubClient

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -4,6 +4,8 @@
  */
 package com.microsoft.azure.eventhubs;
 
+import com.microsoft.azure.eventhubs.amqp.AmqpException;
+
 import java.io.IOException;
 import java.nio.channels.UnresolvedAddressException;
 import java.security.InvalidKeyException;
@@ -1409,7 +1411,13 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
 						}
 						else if (error instanceof Exception) {
 							if ((error instanceof ExecutionException) && (error.getCause() != null) && (error.getCause() instanceof Exception)) {
-								lastException = (Exception)error.getCause();
+							    if(error.getCause() instanceof AmqpException) {
+							        lastException = ExceptionUtil.toException(((AmqpException) error.getCause()).getError());
+                                }
+                                else {
+							        lastException = (Exception)error.getCause();
+                                }
+
 								completeWith = error.getCause();
 							}
 							else {


### PR DESCRIPTION
A retry is only attempted if "lastException" is an instance of EventHubException. Making AmqpExceptions into EventHubExceptions ensures that those types of exceptions are retried when appropriate. 