### PR TITLE
Modifying traces in PartitionReceiver to avoid NPE

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -406,7 +406,7 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
                 totalMilliSeconds = Long.MAX_VALUE;
                 if (TRACE_LOGGER.isWarnEnabled()) {
                     TRACE_LOGGER.warn(
-                            String.format("receiverPath[%s], action[createReceiveLink], warning[starting receiver from epoch+Long.Max]", this.internalReceiver.getReceivePath()));
+                            "receiver not yet created, action[createReceiveLink], warning[starting receiver from epoch+Long.Max]");
                 }
             }
 


### PR DESCRIPTION
See line 401. If ```lastReceivedMessage``` is ```null```, then ```this.internalReceiver``` must be ```null```, so a NPE will be thrown every time this trace is output. 