### PR TITLE
Removing prefetchCount upper bound

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -42,7 +42,7 @@ import com.microsoft.azure.eventhubs.amqp.AmqpConstants;
  */
 public final class PartitionReceiver extends ClientEntity implements IReceiverSettingsProvider {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionReceiver.class);
-    private static final int MINIMUM_PREFETCH_COUNT = 10;
+    static final int MINIMUM_PREFETCH_COUNT = 10;
 
     static final int DEFAULT_PREFETCH_COUNT = 999;
     static final long NULL_EPOCH = 0;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -43,7 +43,6 @@ import com.microsoft.azure.eventhubs.amqp.AmqpConstants;
 public final class PartitionReceiver extends ClientEntity implements IReceiverSettingsProvider {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionReceiver.class);
     private static final int MINIMUM_PREFETCH_COUNT = 10;
-    private static final int MAXIMUM_PREFETCH_COUNT = 999;
 
     static final int DEFAULT_PREFETCH_COUNT = 999;
     static final long NULL_EPOCH = 0;
@@ -190,9 +189,9 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
      * @throws EventHubException if setting prefetchCount encounters error
      */
     public final void setPrefetchCount(final int prefetchCount) throws EventHubException {
-        if (prefetchCount < PartitionReceiver.MINIMUM_PREFETCH_COUNT || prefetchCount > PartitionReceiver.MAXIMUM_PREFETCH_COUNT) {
+        if (prefetchCount < PartitionReceiver.MINIMUM_PREFETCH_COUNT) {
             throw new IllegalArgumentException(String.format(Locale.US,
-                    "PrefetchCount has to be between %s and %s", PartitionReceiver.MINIMUM_PREFETCH_COUNT, PartitionReceiver.MAXIMUM_PREFETCH_COUNT));
+                    "PrefetchCount has to be above %s", PartitionReceiver.MINIMUM_PREFETCH_COUNT));
         }
 
         this.internalReceiver.setPrefetchCount(prefetchCount);


### PR DESCRIPTION
Per Sreeram this bound was only meant for early stages of development. .NET client doesn't have an upper bound, so we're removing it to match that. 