### PR TITLE
Introduce EventPosition and Support Sequence Number Filtering

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventHubPartitionPump.java
@@ -11,13 +11,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.eventhubs.ReceiverOptions;
-import com.microsoft.azure.eventhubs.ReceiverDisconnectedException;
-import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,12 +107,12 @@ class EventHubPartitionPump extends PartitionPump
     	if (startAt instanceof String)
     	{
     		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(),
-    				(String)startAt, epoch, options);
+    				EventPosition.fromOffset((String)startAt), epoch, options);
     	}
     	else if (startAt instanceof Instant) 
     	{
     		this.internalOperationFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(), this.partitionContext.getPartitionId(),
-    				(Instant)startAt, epoch, options);
+    				EventPosition.fromEnqueuedTime((Instant)startAt), epoch, options);
     	}
     	else
     	{

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
@@ -4,12 +4,8 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.CompletableFuture;
 
+import com.microsoft.azure.eventhubs.*;
 import org.junit.Test;
-
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
 
 public class Repros extends TestBase
 {
@@ -123,7 +119,7 @@ public class Repros extends TestBase
 			
 			System.out.println("Client " + clientSerialNumber + " starting");
 			EventHubClient client = EventHubClient.createFromConnectionStringSync(utils.getConnectionString().toString(), TestUtilities.EXECUTOR_SERVICE);
-			PartitionReceiver receiver = client.createReceiver(utils.getConsumerGroup(), "0", PartitionReceiver.START_OF_STREAM).get();
+			PartitionReceiver receiver = client.createReceiver(utils.getConsumerGroup(), "0", EventPosition.fromStartOfStream()).get();
 					//client.createEpochReceiver(utils.getConsumerGroup(), "0", PartitionReceiver.START_OF_STREAM, 1).get();
 
 			boolean useReceiveHandler = false;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -580,120 +580,19 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     }
 
     /**
-     * Synchronous version of {@link #createReceiver(String, String, String)}.
+     * Synchronous version of {@link #createReceiver(String, String, EventPosition)}.
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      */
     @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset)
+    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition)
             throws EventHubException {
         try {
-            return this.createReceiver(consumerGroupName, partitionId, startingOffset).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * The receiver is created for a specific EventHub partition from the specific consumer group.
-     * <p>NOTE: There can be a maximum number of receivers that can run in parallel per ConsumerGroup per Partition.
-     * The limit is enforced by the Event Hub service - current limit is 5 receivers in parallel. Having multiple receivers
-     * reading from offsets that are far apart on the same consumer group / partition combo will have significant performance Impact.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @return a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset)
-            throws EventHubException {
-        return this.createReceiver(consumerGroupName, partitionId, startingOffset, false);
-    }
-
-    /**
-     * Synchronous version of {@link #createReceiver(String, String, String, boolean)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive)
-            throws EventHubException {
-        try {
-            return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-
-        }
-    }
-
-    /**
-     * Create the EventHub receiver with given partition id and start receiving from the specified starting offset.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
-     * @return a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive)
-            throws EventHubException {
-        return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, null);
-    }
-
-    /**
-     * Synchronous version of {@link #createReceiver(String, String, Instant)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime)
-            throws EventHubException {
-        try {
-            return this.createReceiver(consumerGroupName, partitionId, dateTime).get();
+            return this.createReceiver(consumerGroupName, partitionId, eventPosition).get();
         } catch (InterruptedException | ExecutionException exception) {
             if (exception instanceof InterruptedException) {
                 // Re-assert the thread's interrupted status
@@ -717,85 +616,32 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime)
-            throws EventHubException {
-        return this.createReceiver(consumerGroupName, partitionId, dateTime, null);
-    }
-
-    /**
-     * Synchronous version of {@link #createReceiver(String, String, String)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        try {
-            return this.createReceiver(consumerGroupName, partitionId, startingOffset, receiverOptions).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * The receiver is created for a specific EventHub partition from the specific consumer group.
-     * <p>NOTE: There can be a maximum number of receivers that can run in parallel per ConsumerGroup per Partition.
-     * The limit is enforced by the Event Hub service - current limit is 5 receivers in parallel. Having multiple receivers
-     * reading from offsets that are far apart on the same consumer group / partition combo will have significant performance Impact.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @return a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      * @see PartitionReceiver
      */
     @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, final ReceiverOptions receiverOptions)
+    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition)
             throws EventHubException {
-        return this.createReceiver(consumerGroupName, partitionId, startingOffset, false, receiverOptions);
+        return this.createReceiver(consumerGroupName, partitionId, eventPosition, null);
     }
 
     /**
-     * Synchronous version of {@link #createReceiver(String, String, String, boolean)}.
+     * Synchronous version of {@link #createReceiver(String, String, EventPosition)}.
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param receiverOptions   the set of options to enable on the event hubs receiver
      * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      */
     @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final ReceiverOptions receiverOptions)
+    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final ReceiverOptions receiverOptions)
             throws EventHubException {
         try {
-            return this.createReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, receiverOptions).get();
+            return this.createReceiver(consumerGroupName, partitionId, eventPosition, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
             if (exception instanceof InterruptedException) {
                 // Re-assert the thread's interrupted status
@@ -819,84 +665,34 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param receiverOptions   the set of options to enable on the event hubs receiver
      * @return a CompletableFuture that would result in a PartitionReceiver instance when it is completed.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      * @see PartitionReceiver
      */
     @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final ReceiverOptions receiverOptions)
+    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final ReceiverOptions receiverOptions)
             throws EventHubException {
-        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, PartitionReceiver.NULL_EPOCH, false, receiverOptions, this.executor);
+        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, eventPosition, PartitionReceiver.NULL_EPOCH, false, receiverOptions, this.executor);
     }
 
     /**
-     * Synchronous version of {@link #createReceiver(String, String, Instant)}.
+     * Synchronous version of {@link #createEpochReceiver(String, String, EventPosition, long)}.
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        try {
-            return this.createReceiver(consumerGroupName, partitionId, dateTime, receiverOptions).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * Create the EventHub receiver with given partition id and start receiving from the specified starting offset.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, PartitionReceiver.NULL_EPOCH, false, receiverOptions, this.executor);
-    }
-
-    /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, String, long)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
      * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      */
     @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch)
+
+    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch)
             throws EventHubException {
         try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, epoch).get();
+            return this.createEpochReceiver(consumerGroupName, partitionId, eventPosition, epoch).get();
         } catch (InterruptedException | ExecutionException exception) {
             if (exception instanceof InterruptedException) {
                 // Re-assert the thread's interrupted status
@@ -927,7 +723,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
      * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
@@ -935,27 +731,27 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @see ReceiverDisconnectedException
      */
     @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch)
+    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch)
             throws EventHubException {
-        return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, false, epoch);
+        return this.createEpochReceiver(consumerGroupName, partitionId, eventPosition, epoch, null);
     }
 
     /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, String, boolean, long)}.
+     * Synchronous version of {@link #createEpochReceiver(String, String, EventPosition, long)}.
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
+     * @param receiverOptions   the set of options to enable on the event hubs receiver
      * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
      * @throws EventHubException if Service Bus service encountered problems during the operation.
      */
     @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch)
+    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch, final ReceiverOptions receiverOptions)
             throws EventHubException {
         try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch).get();
+            return this.createEpochReceiver(consumerGroupName, partitionId, eventPosition, epoch, receiverOptions).get();
         } catch (InterruptedException | ExecutionException exception) {
             if (exception instanceof InterruptedException) {
                 // Re-assert the thread's interrupted status
@@ -986,125 +782,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      *
      * @param consumerGroupName the consumer group name that this receiver should be grouped under.
      * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     * @see ReceiverDisconnectedException
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch)
-            throws EventHubException {
-        return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch, null);
-    }
-
-    /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, Instant, long)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch)
-            throws EventHubException {
-        try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     * <p>
-     * It is important to pay attention to the following when creating epoch based receiver:
-     * <ul>
-     * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
-     * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
-     * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
-     * </ul>
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param epoch             a unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     * @see ReceiverDisconnectedException
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch)
-            throws EventHubException {
-        return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch, null);
-    }
-
-    /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, String, long)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, epoch, receiverOptions).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     * <p>
-     * It is important to pay attention to the following when creating epoch based receiver:
-     * <ul>
-     * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
-     * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
-     * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
-     * </ul>
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
+     * @param eventPosition     the position to start receiving the events from. See {@link EventPosition}
      * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
      * @param receiverOptions   the set of options to enable on the event hubs receiver
      * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
@@ -1113,131 +791,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
      * @see ReceiverDisconnectedException
      */
     @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, final long epoch, final ReceiverOptions receiverOptions)
+    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch, final ReceiverOptions receiverOptions)
             throws EventHubException {
-        return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, false, epoch, receiverOptions);
-    }
-
-    /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, String, boolean, long)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, startingOffset, offsetInclusive, epoch, receiverOptions).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     * <p>
-     * It is important to pay attention to the following when creating epoch based receiver:
-     * <ul>
-     * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
-     * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
-     * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
-     * </ul>
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param startingOffset    the offset to start receiving the events from. To receive from start of the stream use: {@link PartitionReceiver#START_OF_STREAM}
-     * @param offsetInclusive   if set to true, the startingOffset is treated as an inclusive offset - meaning the first event returned is the one that has the starting offset. Normally first event returned is the event after the starting offset.
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     * @see ReceiverDisconnectedException
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final String startingOffset, boolean offsetInclusive, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, startingOffset, offsetInclusive, null, epoch, true, receiverOptions, this.executor);
-    }
-
-    /**
-     * Synchronous version of {@link #createEpochReceiver(String, String, Instant, long)}.
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param epoch             an unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return PartitionReceiver instance which can be used for receiving {@link EventData}.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     */
-    @Override
-    public final PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        try {
-            return this.createEpochReceiver(consumerGroupName, partitionId, dateTime, epoch, receiverOptions).get();
-        } catch (InterruptedException | ExecutionException exception) {
-            if (exception instanceof InterruptedException) {
-                // Re-assert the thread's interrupted status
-                Thread.currentThread().interrupt();
-            }
-
-            Throwable throwable = exception.getCause();
-            if (throwable instanceof EventHubException) {
-                throw (EventHubException) throwable;
-            } else if (throwable instanceof RuntimeException) {
-                throw (RuntimeException) throwable;
-            } else {
-                throw new RuntimeException(exception);
-            }
-        }
-    }
-
-    /**
-     * Create a Epoch based EventHub receiver with given partition id and start receiving from the beginning of the partition stream.
-     * The receiver is created for a specific EventHub Partition from the specific consumer group.
-     * <p>
-     * It is important to pay attention to the following when creating epoch based receiver:
-     * <ul>
-     * <li> Ownership enforcement - Once you created an epoch based receiver, you cannot create a non-epoch receiver to the same consumerGroup-Partition combo until all receivers to the combo are closed.
-     * <li> Ownership stealing - If a receiver with higher epoch value is created for a consumerGroup-Partition combo, any older epoch receiver to that combo will be force closed.
-     * <li> Any receiver closed due to lost of ownership to a consumerGroup-Partition combo will get ReceiverDisconnectedException for all operations from that receiver.
-     * </ul>
-     *
-     * @param consumerGroupName the consumer group name that this receiver should be grouped under.
-     * @param partitionId       the partition Id that the receiver belongs to. All data received will be from this partition only.
-     * @param dateTime          the date time instant that receive operations will start receive events from. Events received will have {@link EventData.SystemProperties#getEnqueuedTime()} later than this Instant.
-     * @param epoch             a unique identifier (epoch value) that the service uses, to enforce partition/lease ownership.
-     * @param receiverOptions   the set of options to enable on the event hubs receiver
-     * @return a CompletableFuture that would result in a PartitionReceiver when it is completed.
-     * @throws EventHubException if Service Bus service encountered problems during the operation.
-     * @see PartitionReceiver
-     * @see ReceiverDisconnectedException
-     */
-    @Override
-    public final CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final Instant dateTime, final long epoch, final ReceiverOptions receiverOptions)
-            throws EventHubException {
-        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, null, false, dateTime, epoch, true, receiverOptions, this.executor);
+        return PartitionReceiver.create(this.underlyingFactory, this.eventHubName, consumerGroupName, partitionId, eventPosition, epoch, true, receiverOptions, this.executor);
     }
 
     @Override

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs;
+
+import java.time.Instant;
+
+/**
+ * Defines a position of an {@link EventData} in the event hub partition.
+ * The position can be an Offset, Sequence Number, or EnqueuedTime.
+ */
+public class EventPosition {
+
+    private final String offset;
+    private final Long sequenceNumber;
+    private final Instant dateTime;
+    private final Boolean inclusive;
+
+    private EventPosition(String o, Long s, Instant d, Boolean i) {
+        this.offset = o;
+        this.sequenceNumber = s;
+        this.dateTime = d;
+        this.inclusive = i;
+    }
+
+    /**
+     * Creates a position at the given offset. The specified event will not be included.
+     * Instead, the next event is returned.
+     * @param offset    is the byte offset of the event.
+     * @return An {@link EventPosition} object.
+     */
+    public static EventPosition fromOffset(String offset) {
+        return EventPosition.fromOffset(offset, false);
+    }
+
+    /**
+     * Creates a position at the given offset.
+     * @param offset    is the byte offset of the event.
+     * @param inclusive will include the specified event when set to true; otherwise, the next event is returned.
+     * @return An {@link EventPosition} object.
+     */
+    public static EventPosition fromOffset(String offset, boolean inclusive) {
+        return new EventPosition(offset, null, null, inclusive);
+    }
+
+    /**
+     * Creates a position at the given sequence number. The specified event will not be included.
+     * Instead, the next event is returned.
+     * @param sequenceNumber is the sequence number of the event.
+     * @return An {@link EventPosition} object.
+     */
+    public static EventPosition fromSequenceNumber(Long sequenceNumber) {
+        return EventPosition.fromSequenceNumber(sequenceNumber, false);
+    }
+
+    /**
+     * Creates a position at the given sequence number. The specified event will not be included.
+     * Instead, the next event is returned.
+     * @param sequenceNumber    is the sequence number of the event.
+     * @param inclusive         will include the specified event when set to true; otherwise, the next event is returned.
+     * @return An {@link EventPosition} object.
+     */
+    public static EventPosition fromSequenceNumber(Long sequenceNumber, boolean inclusive) {
+        return new EventPosition(null, sequenceNumber, null, inclusive);
+    }
+
+    /**
+     * Creates a position at the given {@link Instant}.
+     * @param dateTime  is the enqueued time of the event.
+     * @return An {@link EventPosition} object.
+     */
+    public static EventPosition fromEnqueuedTime(Instant dateTime) {
+        return new EventPosition(null, null, dateTime, null);
+    }
+
+    /**
+     * @return An {@link EventPosition} with position set to the start of the Event Hubs stream.
+     */
+    public static EventPosition fromStartOfStream() {
+        return new EventPosition(PartitionReceiver.START_OF_STREAM, null, null, false);
+    }
+
+    /**
+     * @param inclusive When true, the last event in the partition will be sent. When false,
+     *                  the last event will be skipped, and only new events will be received.
+     * @return An {@link EventPosition} with position set to the end of the Event Hubs stream.
+     */
+    public static EventPosition fromEndOfStream(boolean inclusive) {
+        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, inclusive);
+    }
+
+    /**
+     * @return the byte offset of the event.
+     */
+    public String getOffset() {
+        return this.offset;
+    }
+
+    /**
+     * @return true if the current event will be included. false if the current event will not be included.
+     */
+    public Boolean getInclusive() {
+        return this.inclusive;
+    }
+
+    /**
+     * @return the sequence number of the event.
+     */
+    public Long getSequenceNumber() {
+        return this.sequenceNumber;
+    }
+
+    /**
+     * @return the enqueued time of the event.
+     */
+    public Instant getEnqueuedTime() {
+        return this.dateTime;
+    }
+
+    String getFilterType() {
+        if (this.offset != null) {
+            return "offset";
+        }
+
+        if (this.sequenceNumber != null) {
+            return "sequenceNumber";
+        }
+
+        if (this.dateTime != null) {
+            return "enqueuedTime";
+        }
+
+        throw new IllegalArgumentException("No starting position was set.");
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -18,6 +18,18 @@ public class EventPosition {
 
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(EventPosition.class);
 
+    /**
+     * This is a constant defined to represent the start of a partition stream in EventHub.
+     */
+    static final String START_OF_STREAM = "-1";
+
+    /**
+     * This is a constant defined to represent the current end of a partition stream in EventHub.
+     * This can be used as an offset argument in receiver creation to start receiving from the latest
+     * event, instead of a specific offset or point in time.
+     */
+    static final String END_OF_STREAM = "@latest";
+
     private final String offset;
     private final Long sequenceNumber;
     private final Instant dateTime;
@@ -86,7 +98,7 @@ public class EventPosition {
      * @return An {@link EventPosition} with position set to the start of the Event Hubs stream.
      */
     public static EventPosition fromStartOfStream() {
-        return new EventPosition(PartitionReceiver.START_OF_STREAM, null, null, true);
+        return new EventPosition(START_OF_STREAM, null, null, true);
     }
 
     /**
@@ -96,7 +108,7 @@ public class EventPosition {
      * @return An {@link EventPosition} with position set to the end of the Event Hubs stream.
      */
     public static EventPosition fromEndOfStream() {
-        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, false);
+        return new EventPosition(END_OF_STREAM, null, null, false);
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -112,47 +112,6 @@ public class EventPosition {
         return new EventPosition(END_OF_STREAM, null, null, false);
     }
 
-    /**
-     * Gets the offset of the event at the position. It can be null if the position is created
-     * from a sequence number or enqueued time.
-     *
-     * @return the byte offset of the event.
-     */
-    String getOffset() {
-        return this.offset;
-    }
-
-    /**
-     * Indicates if the current event at the specified offset is included or not.
-     * It is only applicable if offset or sequence number is set. If offset or
-     * sequence number is not set, this will return null.
-     *
-     * @return the inclusive flag
-     */
-    Boolean getInclusiveFlag() {
-        return this.inclusiveFlag;
-    }
-
-    /**
-     * Gets the sequence number of the event at the position. It can be null if the position is created
-     * from an offset or enqueued time.
-     *
-     * @return the sequence number of the event.
-     */
-    Long getSequenceNumber() {
-        return this.sequenceNumber;
-    }
-
-    /**
-     * Gets the enqueued time of the event at the position. It can be null if the position is created
-     * from an offset or a sequence number.
-     *
-     * @return the enqueued time of the event.
-     */
-    Instant getEnqueuedTime() {
-        return this.dateTime;
-    }
-
     String getExpression() {
         // order of preference
         if (this.offset != null) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -81,19 +81,22 @@ public class EventPosition {
     }
 
     /**
+     * This will return an EventPosition that includes the first event in the Event Hubs partition.
+     *
      * @return An {@link EventPosition} with position set to the start of the Event Hubs stream.
      */
     public static EventPosition fromStartOfStream() {
-        return new EventPosition(PartitionReceiver.START_OF_STREAM, null, null, false);
+        return new EventPosition(PartitionReceiver.START_OF_STREAM, null, null, true);
     }
 
     /**
-     * @param inclusiveFlag When true, the last event in the partition will be sent. When false,
-     *                  the last event will be skipped, and only new events will be received.
+     * The last event in the Event Hubs partition is not included. The returned EventPosition will
+     * future events that arrive to this EventHubs partition.
+     *
      * @return An {@link EventPosition} with position set to the end of the Event Hubs stream.
      */
-    public static EventPosition fromEndOfStream(boolean inclusiveFlag) {
-        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, inclusiveFlag);
+    public static EventPosition fromEndOfStream() {
+        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, false);
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -15,13 +15,13 @@ public class EventPosition {
     private final String offset;
     private final Long sequenceNumber;
     private final Instant dateTime;
-    private final Boolean inclusive;
+    private final Boolean inclusiveFlag;
 
     private EventPosition(String o, Long s, Instant d, Boolean i) {
         this.offset = o;
         this.sequenceNumber = s;
         this.dateTime = d;
-        this.inclusive = i;
+        this.inclusiveFlag = i;
     }
 
     /**
@@ -37,11 +37,11 @@ public class EventPosition {
     /**
      * Creates a position at the given offset.
      * @param offset    is the byte offset of the event.
-     * @param inclusive will include the specified event when set to true; otherwise, the next event is returned.
+     * @param inclusiveFlag will include the specified event when set to true; otherwise, the next event is returned.
      * @return An {@link EventPosition} object.
      */
-    public static EventPosition fromOffset(String offset, boolean inclusive) {
-        return new EventPosition(offset, null, null, inclusive);
+    public static EventPosition fromOffset(String offset, boolean inclusiveFlag) {
+        return new EventPosition(offset, null, null, inclusiveFlag);
     }
 
     /**
@@ -58,11 +58,11 @@ public class EventPosition {
      * Creates a position at the given sequence number. The specified event will not be included.
      * Instead, the next event is returned.
      * @param sequenceNumber    is the sequence number of the event.
-     * @param inclusive         will include the specified event when set to true; otherwise, the next event is returned.
+     * @param inclusiveFlag         will include the specified event when set to true; otherwise, the next event is returned.
      * @return An {@link EventPosition} object.
      */
-    public static EventPosition fromSequenceNumber(Long sequenceNumber, boolean inclusive) {
-        return new EventPosition(null, sequenceNumber, null, inclusive);
+    public static EventPosition fromSequenceNumber(Long sequenceNumber, boolean inclusiveFlag) {
+        return new EventPosition(null, sequenceNumber, null, inclusiveFlag);
     }
 
     /**
@@ -82,15 +82,18 @@ public class EventPosition {
     }
 
     /**
-     * @param inclusive When true, the last event in the partition will be sent. When false,
+     * @param inclusiveFlag When true, the last event in the partition will be sent. When false,
      *                  the last event will be skipped, and only new events will be received.
      * @return An {@link EventPosition} with position set to the end of the Event Hubs stream.
      */
-    public static EventPosition fromEndOfStream(boolean inclusive) {
-        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, inclusive);
+    public static EventPosition fromEndOfStream(boolean inclusiveFlag) {
+        return new EventPosition(PartitionReceiver.END_OF_STREAM, null, null, inclusiveFlag);
     }
 
     /**
+     * Gets the offset of the event at the position. It can be null if the position is created
+     * from a sequence number or enqueued time.
+     *
      * @return the byte offset of the event.
      */
     public String getOffset() {
@@ -98,13 +101,20 @@ public class EventPosition {
     }
 
     /**
-     * @return true if the current event will be included. false if the current event will not be included.
+     * Indicates if the current event at the specified offset is included or not.
+     * It is only applicable if offset or sequence number is set. If offset or
+     * sequence number is not set, this will return null.
+     *
+     * @return the inclusive flag
      */
-    public Boolean getInclusive() {
-        return this.inclusive;
+    public Boolean getInclusiveFlag() {
+        return this.inclusiveFlag;
     }
 
     /**
+     * Gets the sequence number of the event at the position. It can be null if the position is created
+     * from an offset or enqueued time.
+     *
      * @return the sequence number of the event.
      */
     public Long getSequenceNumber() {
@@ -112,6 +122,9 @@ public class EventPosition {
     }
 
     /**
+     * Gets the enqueued time of the event at the position. It can be null if the position is created
+     * from an offset or a sequence number.
+     *
      * @return the enqueued time of the event.
      */
     public Instant getEnqueuedTime() {
@@ -132,5 +145,11 @@ public class EventPosition {
         }
 
         throw new IllegalArgumentException("No starting position was set.");
+    }
+
+    @Override
+    public String toString() {
+        return String.format("offset[%s], sequenceNumber[%s], enqueuedTime[%s], inclusiveFlag[%s]",
+                this.offset, this.sequenceNumber, this.dateTime.toEpochMilli(), this.inclusiveFlag);
     }
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -93,19 +93,20 @@ public class EventPosition {
     }
 
     /**
-     * This will return an EventPosition that includes the first event in the Event Hubs partition.
+     * Returns the position for the start of a stream. Provide this position in receiver creation
+     * to start receiving from the first available event in the partition.
      *
-     * @return An {@link EventPosition} with position set to the start of the Event Hubs stream.
+     * @return An {@link EventPosition} set to the start of an Event Hubs stream.
      */
     public static EventPosition fromStartOfStream() {
         return new EventPosition(START_OF_STREAM, null, null, true);
     }
 
     /**
-     * The last event in the Event Hubs partition is not included. The returned EventPosition will
-     * future events that arrive to this EventHubs partition.
+     * Returns the position for the end of a stream. Provide this position in receiver creation
+     * to start receiving from the next available event in the partition after the receiver is created.
      *
-     * @return An {@link EventPosition} with position set to the end of the Event Hubs stream.
+     * @return An {@link EventPosition} set to the end of an Event Hubs stream.
      */
     public static EventPosition fromEndOfStream() {
         return new EventPosition(END_OF_STREAM, null, null, false);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventPosition.java
@@ -105,7 +105,7 @@ public class EventPosition {
      *
      * @return the byte offset of the event.
      */
-    public String getOffset() {
+    String getOffset() {
         return this.offset;
     }
 
@@ -116,7 +116,7 @@ public class EventPosition {
      *
      * @return the inclusive flag
      */
-    public Boolean getInclusiveFlag() {
+    Boolean getInclusiveFlag() {
         return this.inclusiveFlag;
     }
 
@@ -126,7 +126,7 @@ public class EventPosition {
      *
      * @return the sequence number of the event.
      */
-    public Long getSequenceNumber() {
+    Long getSequenceNumber() {
         return this.sequenceNumber;
     }
 
@@ -136,7 +136,7 @@ public class EventPosition {
      *
      * @return the enqueued time of the event.
      */
-    public Instant getEnqueuedTime() {
+    Instant getEnqueuedTime() {
         return this.dateTime;
     }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/IEventHubClient.java
@@ -4,112 +4,57 @@
  */
 package com.microsoft.azure.eventhubs;
 
-import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
 public interface IEventHubClient {
-    void sendSync(EventData data)
-            throws EventHubException;
+
+    void sendSync(EventData data) throws EventHubException;
 
     CompletableFuture<Void> send(EventData data);
 
-    void sendSync(Iterable<EventData> eventDatas)
-            throws EventHubException;
-
-    void sendSync(EventDataBatch eventDatas)
-        throws EventHubException;
+    void sendSync(Iterable<EventData> eventDatas) throws EventHubException;
 
     CompletableFuture<Void> send(Iterable<EventData> eventDatas);
 
+    void sendSync(EventDataBatch eventDatas) throws EventHubException;
+
     CompletableFuture<Void> send(EventDataBatch eventDatas);
 
-    void sendSync(EventData eventData, String partitionKey)
-            throws EventHubException;
+    void sendSync(EventData eventData, String partitionKey) throws EventHubException;
 
     CompletableFuture<Void> send(EventData eventData, String partitionKey);
 
-    void sendSync(Iterable<EventData> eventDatas, String partitionKey)
-            throws EventHubException;
+    void sendSync(Iterable<EventData> eventDatas, String partitionKey) throws EventHubException;
 
     CompletableFuture<Void> send(Iterable<EventData> eventDatas, String partitionKey);
 
-    PartitionSender createPartitionSenderSync(String partitionId)
-            throws EventHubException, IllegalArgumentException;
+    PartitionSender createPartitionSenderSync(String partitionId) throws EventHubException, IllegalArgumentException;
 
-    CompletableFuture<PartitionSender> createPartitionSender(String partitionId)
-                    throws EventHubException;
+    CompletableFuture<PartitionSender> createPartitionSender(String partitionId) throws EventHubException;
 
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset)
-                            throws EventHubException;
+    PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition)
+            throws EventHubException;
 
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset)
-                                    throws EventHubException;
+    CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition)
+            throws EventHubException;
 
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive)
-                                            throws EventHubException;
+    PartitionReceiver createReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final ReceiverOptions receiverOptions)
+            throws EventHubException;
 
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive)
-                                                    throws EventHubException;
+    CompletableFuture<PartitionReceiver> createReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final ReceiverOptions receiverOptions)
+            throws EventHubException;
 
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, Instant dateTime)
-                                                            throws EventHubException;
+    PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch)
+            throws EventHubException;
 
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, Instant dateTime)
-                                                                    throws EventHubException;
+    CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch)
+            throws EventHubException;
 
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, ReceiverOptions receiverOptions)
-                                                                            throws EventHubException;
+    PartitionReceiver createEpochReceiverSync(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch, final ReceiverOptions receiverOptions)
+            throws EventHubException;
 
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, ReceiverOptions receiverOptions)
-                                                                                    throws EventHubException;
-
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, ReceiverOptions receiverOptions)
-                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, ReceiverOptions receiverOptions)
-                                                                                                    throws EventHubException;
-
-    PartitionReceiver createReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, ReceiverOptions receiverOptions)
-                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createReceiver(String consumerGroupName, String partitionId, Instant dateTime, ReceiverOptions receiverOptions)
-                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, long epoch)
-                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, long epoch)
-                                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch)
-                                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch)
-                                                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, long epoch)
-                                                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, Instant dateTime, long epoch)
-                                                                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, String startingOffset, boolean offsetInclusive, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                                    throws EventHubException;
-
-    PartitionReceiver createEpochReceiverSync(String consumerGroupName, String partitionId, Instant dateTime, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                                            throws EventHubException;
-
-    CompletableFuture<PartitionReceiver> createEpochReceiver(String consumerGroupName, String partitionId, Instant dateTime, long epoch, ReceiverOptions receiverOptions)
-                                                                                                                                                                                                                    throws EventHubException;
+    CompletableFuture<PartitionReceiver> createEpochReceiver(final String consumerGroupName, final String partitionId, final EventPosition eventPosition, final long epoch, final ReceiverOptions receiverOptions)
+            throws EventHubException;
 
     CompletableFuture<Void> onClose();
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -47,6 +47,11 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
     static final int DEFAULT_PREFETCH_COUNT = 999;
     static final long NULL_EPOCH = 0;
 
+
+    // Both constants should be removed before 1.0.0 release
+    public static String START_OF_STREAM = "-1";
+    public static String END_OF_STREAM = "@latest";
+
     private final String partitionId;
     private final MessagingFactory underlyingFactory;
     private final String eventHubName;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -14,8 +14,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutionException;
-import java.util.function.BiConsumer;
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -50,14 +50,14 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
     /**
      * This is a constant defined to represent the start of a partition stream in EventHub.
      */
-    public static final String START_OF_STREAM = "-1";
+    static final String START_OF_STREAM = "-1";
 
     /**
      * This is a constant defined to represent the current end of a partition stream in EventHub.
      * This can be used as an offset argument in receiver creation to start receiving from the latest
      * event, instead of a specific offset or point in time.
      */
-    public static final String END_OF_STREAM = "@latest";
+    static final String END_OF_STREAM = "@latest";
 
     private final String partitionId;
     private final MessagingFactory underlyingFactory;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -47,18 +47,6 @@ public final class PartitionReceiver extends ClientEntity implements IReceiverSe
     static final int DEFAULT_PREFETCH_COUNT = 999;
     static final long NULL_EPOCH = 0;
 
-    /**
-     * This is a constant defined to represent the start of a partition stream in EventHub.
-     */
-    static final String START_OF_STREAM = "-1";
-
-    /**
-     * This is a constant defined to represent the current end of a partition stream in EventHub.
-     * This can be used as an offset argument in receiver creation to start receiving from the latest
-     * event, instead of a specific offset or point in time.
-     */
-    static final String END_OF_STREAM = "@latest";
-
     private final String partitionId;
     private final MessagingFactory underlyingFactory;
     private final String eventHubName;

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/ConcurrentReceiversTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/ConcurrentReceiversTest.java
@@ -13,20 +13,16 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
+
+import com.microsoft.azure.eventhubs.*;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.PartitionReceiveHandler;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.EventHubException;
 
 public class ConcurrentReceiversTest extends ApiTestBase
 {
@@ -61,7 +57,7 @@ public class ConcurrentReceiversTest extends ApiTestBase
 		for(int i=0; i < partitionCount; i++)
 		{
 			final int index = i;
-			receiverFutures[i] = ehClient.createReceiver(consumerGroupName, Integer.toString(i), Instant.now()).thenAcceptAsync(
+			receiverFutures[i] = ehClient.createReceiver(consumerGroupName, Integer.toString(i), EventPosition.fromEnqueuedTime(Instant.now())).thenAcceptAsync(
 					new Consumer<PartitionReceiver>(){
 						@Override
 						public void accept(final PartitionReceiver t) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.azure.eventhubs.concurrency;
 
+import java.awt.*;
 import java.util.concurrent.*;
 
 import org.junit.*;
@@ -40,8 +41,8 @@ public class EventHubClientTest extends ApiTestBase {
 					TestBase.pushEventsToPartition(ehClient, partitionId, 10).get();
 					firstOne = false;
 				}
-				
-				PartitionReceiver receiver = ehClient.createReceiverSync(consumerGroupName, partitionId, PartitionReceiver.START_OF_STREAM, false);
+
+				PartitionReceiver receiver = ehClient.createReceiverSync(consumerGroupName, partitionId, EventPosition.fromStartOfStream());
 				try {
 					Assert.assertTrue(receiver.receiveSync(100).iterator().hasNext());
 				} finally {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/BackCompatTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/BackCompatTest.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.azure.eventhubs.eventdata;
 
+import java.awt.*;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Instant;
@@ -11,6 +12,7 @@ import java.util.HashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
+import com.microsoft.azure.eventhubs.*;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Binary;
 import org.apache.qpid.proton.amqp.messaging.ApplicationProperties;
@@ -21,15 +23,8 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.MessageSender;
-import com.microsoft.azure.eventhubs.MessagingFactory;
-import com.microsoft.azure.eventhubs.EventHubException;
 
 public class BackCompatTest extends ApiTestBase
 {
@@ -72,7 +67,7 @@ public class BackCompatTest extends ApiTestBase
 
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString, TestContext.EXECUTOR_SERVICE);
 		msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
-		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
+		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromEnqueuedTime(Instant.now()));
 		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
 		
                 // until version 0.10.0 - we used to have Properties as HashMap<String,String> 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropAmqpPropertiesTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropAmqpPropertiesTest.java
@@ -99,7 +99,7 @@ public class InteropAmqpPropertiesTest extends ApiTestBase
 
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString, TestContext.EXECUTOR_SERVICE);
 		msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
-		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
+		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromEnqueuedTime(Instant.now()));
 		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
 		partitionEventSender = ehClient.createPartitionSenderSync(partitionId);
 		
@@ -139,7 +139,7 @@ public class InteropAmqpPropertiesTest extends ApiTestBase
 				"receiver1", 
 				connStrBuilder.getEntityPath() + "/ConsumerGroups/" + TestContext.getConsumerGroupName() + "/Partitions/" + partitionId,
 				100,
-				ehClient.createReceiver(TestContext.getConsumerGroupName(), partitionId, reSentAndReceivedEvent.getSystemProperties().getOffset(), false).get()).get();
+				ehClient.createReceiver(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromOffset(reSentAndReceivedEvent.getSystemProperties().getOffset(), false)).get()).get();
                 
                 reSendAndReceivedMessage = msgReceiver.receive(10).get().iterator().next();
 	}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropEventBodyTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropEventBodyTest.java
@@ -49,7 +49,7 @@ public class InteropEventBodyTest extends ApiTestBase {
 
         ehClient = EventHubClient.createFromConnectionStringSync(connectionString, TestContext.EXECUTOR_SERVICE);
         msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
-        receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
+        receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromEnqueuedTime(Instant.now()));
         partitionSender = ehClient.createPartitionSenderSync(partitionId);
         partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
         

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/MsgFactoryOpenCloseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/MsgFactoryOpenCloseTest.java
@@ -4,13 +4,7 @@
  */
 package com.microsoft.azure.eventhubs.exceptioncontracts;
 
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.EventData;
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.MessagingFactory;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.eventhubs.PartitionSender;
-import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.*;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.FaultInjectingReactorFactory;
 import com.microsoft.azure.eventhubs.lib.TestContext;
@@ -52,7 +46,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
                     executor);
 
             final PartitionReceiver receiver = ehClient.createReceiverSync(
-                    TestContext.getConsumerGroupName(), PARTITION_ID, Instant.now());
+                    TestContext.getConsumerGroupName(), PARTITION_ID, EventPosition.fromEnqueuedTime(Instant.now()));
             final PartitionSender sender = ehClient.createPartitionSenderSync(PARTITION_ID);
             sender.sendSync(new EventData("test data - string".getBytes()));
             Iterable<EventData> events = receiver.receiveSync(10);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
@@ -135,7 +135,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 				correctConnectionString.getSasKey());
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
-		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, PartitionReceiver.START_OF_STREAM);
+		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, EventPosition.fromStartOfStream());
 	}
 
 	@Test (expected = IllegalEntityException.class)
@@ -163,7 +163,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 				correctConnectionString.getSasKey());
 
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
-		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, PartitionReceiver.START_OF_STREAM);
+		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, EventPosition.fromStartOfStream());
 	}
 	
 	@After

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
@@ -38,7 +38,7 @@ public class SendLargeMessageTest extends ApiTestBase
 		sender = ehClient.createPartitionSender(partitionId).get();
 		
 		receiverHub = EventHubClient.createFromConnectionString(connStr.toString(), TestContext.EXECUTOR_SERVICE).get();
-		receiver = receiverHub.createReceiver(TestContext.getConsumerGroupName(), partitionId, Instant.now()).get();
+		receiver = receiverHub.createReceiver(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromEnqueuedTime(Instant.now())).get();
 	}
 	
 	@Test()

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -108,7 +108,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
         try {
             final String[] partitionIds = ehClient.getRuntimeInformation().get().getPartitionIds();
             for (int index = 0; index < partitionIds.length; index++) {
-                final PartitionReceiver receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionIds[index], EventPosition.fromEndOfStream(false));
+                final PartitionReceiver receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionIds[index], EventPosition.fromEndOfStream());
                 receiver.setReceiveTimeout(Duration.ofSeconds(5));
                 receiver.setReceiveHandler(validator);
                 receivers.add(receiver);
@@ -135,7 +135,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
     public void sendEventsFullBatchWithAppPropsTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
         final CompletableFuture<Void> validator = new CompletableFuture<>();
-        final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
+        final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream());
         receiver.setReceiveTimeout(Duration.ofSeconds(5));
 
         try {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -108,7 +108,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
         try {
             final String[] partitionIds = ehClient.getRuntimeInformation().get().getPartitionIds();
             for (int index = 0; index < partitionIds.length; index++) {
-                final PartitionReceiver receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionIds[index], PartitionReceiver.END_OF_STREAM);
+                final PartitionReceiver receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionIds[index], EventPosition.fromEndOfStream(false));
                 receiver.setReceiveTimeout(Duration.ofSeconds(5));
                 receiver.setReceiveHandler(validator);
                 receivers.add(receiver);
@@ -135,7 +135,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
     public void sendEventsFullBatchWithAppPropsTest()
             throws EventHubException, InterruptedException, ExecutionException, TimeoutException {
         final CompletableFuture<Void> validator = new CompletableFuture<>();
-        final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.END_OF_STREAM);
+        final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
         receiver.setReceiveTimeout(Duration.ofSeconds(5));
 
         try {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveParallelManualTest.java
@@ -68,7 +68,7 @@ public class ReceiveParallelManualTest extends ApiTestBase
             PartitionReceiver offsetReceiver1 = null;
             try {
                 offsetReceiver1 =
-                        ehClient[partitionIdInt].createReceiverSync(cgName, sPartitionId, PartitionReceiver.START_OF_STREAM, false);
+                        ehClient[partitionIdInt].createReceiverSync(cgName, sPartitionId, EventPosition.fromStartOfStream());
             } catch (EventHubException e) {
                 e.printStackTrace();
             }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
@@ -42,7 +42,7 @@ public class ReceivePumpEventHubTest extends ApiTestBase
 	@Before
 	public void initializeTest() throws EventHubException
 	{
-		receiver = ehClient.createReceiverSync(cgName, partitionId, Instant.now());
+		receiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.now()));
 	}
 	
 	@Test(expected = TimeoutException.class)

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
@@ -70,7 +70,7 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceiverLatestFilter() throws EventHubException, ExecutionException, InterruptedException
 	{
-		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream());
 		Iterable<EventData> events = offsetReceiver.receiveSync(100);
 		Assert.assertTrue(events == null);
 
@@ -144,7 +144,7 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceivedBodyAndProperties() throws EventHubException
 	{
-		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream());
 		datetimeReceiver.setReceiveTimeout(Duration.ofSeconds(5));
 
 	 	Iterable<EventData> drainedEvents =	datetimeReceiver.receiveSync(100);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
@@ -109,6 +109,37 @@ public class ReceiveTest extends ApiTestBase
 		
 		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getSequenceNumber() == event.getSystemProperties().getSequenceNumber() + 1);
 	}
+
+	@Test()
+	public void testReceiverSequenceNumberInclusiveFilter() throws EventHubException
+	{
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
+		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
+
+		Assert.assertTrue(events != null && events.iterator().hasNext());
+		EventData event = events.iterator().next();
+
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromSequenceNumber(event.getSystemProperties().getSequenceNumber(), true));
+		EventData eventReturnedByOffsetReceiver = offsetReceiver.receiveSync(10).iterator().next();
+
+		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getOffset().equals(event.getSystemProperties().getOffset()));
+		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getSequenceNumber() == event.getSystemProperties().getSequenceNumber());
+	}
+
+	@Test()
+	public void testReceiverSequenceNumberNonInclusiveFilter() throws EventHubException
+	{
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
+		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
+
+		Assert.assertTrue(events != null && events.iterator().hasNext());
+
+		EventData event = events.iterator().next();
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromSequenceNumber(event.getSystemProperties().getSequenceNumber(), false));
+		EventData eventReturnedByOffsetReceiver= offsetReceiver.receiveSync(10).iterator().next();
+
+		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getSequenceNumber() == event.getSystemProperties().getSequenceNumber() + 1);
+	}
 	
 	@Test()
 	public void testReceivedBodyAndProperties() throws EventHubException

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
@@ -44,12 +44,12 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceiverStartOfStreamFilters() throws EventHubException
 	{
-		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.START_OF_STREAM, false);
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromStartOfStream());
 		Iterable<EventData> startingEventsUsingOffsetReceiver = offsetReceiver.receiveSync(100);
 		
 		Assert.assertTrue(startingEventsUsingOffsetReceiver != null && startingEventsUsingOffsetReceiver.iterator().hasNext());
 		
-		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
 		Iterable<EventData> startingEventsUsingDateTimeReceiver = datetimeReceiver.receiveSync(100);
 		
 		Assert.assertTrue(startingEventsUsingOffsetReceiver != null && startingEventsUsingDateTimeReceiver.iterator().hasNext());
@@ -70,7 +70,7 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceiverLatestFilter() throws EventHubException, ExecutionException, InterruptedException
 	{
-		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.END_OF_STREAM, false);
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
 		Iterable<EventData> events = offsetReceiver.receiveSync(100);
 		Assert.assertTrue(events == null);
 
@@ -82,13 +82,13 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceiverOffsetInclusiveFilter() throws EventHubException
 	{
-		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
 		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
 		
 		Assert.assertTrue(events != null && events.iterator().hasNext());
 		EventData event = events.iterator().next();
 		
-		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, event.getSystemProperties().getOffset(), true);
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromOffset(event.getSystemProperties().getOffset(), true));
 		EventData eventReturnedByOffsetReceiver = offsetReceiver.receiveSync(10).iterator().next();
 		
 		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getOffset().equals(event.getSystemProperties().getOffset()));
@@ -98,13 +98,13 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceiverOffsetNonInclusiveFilter() throws EventHubException
 	{
-		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
 		Iterable<EventData> events = datetimeReceiver.receiveSync(100);
 		
 		Assert.assertTrue(events != null && events.iterator().hasNext());
 		
 		EventData event = events.iterator().next();
-		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, event.getSystemProperties().getOffset(), false);
+		offsetReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromOffset(event.getSystemProperties().getOffset(), false));
 		EventData eventReturnedByOffsetReceiver= offsetReceiver.receiveSync(10).iterator().next();
 		
 		Assert.assertTrue(eventReturnedByOffsetReceiver.getSystemProperties().getSequenceNumber() == event.getSystemProperties().getSequenceNumber() + 1);
@@ -113,7 +113,7 @@ public class ReceiveTest extends ApiTestBase
 	@Test()
 	public void testReceivedBodyAndProperties() throws EventHubException
 	{
-		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.END_OF_STREAM);
+		datetimeReceiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEndOfStream(false));
 		datetimeReceiver.setReceiveTimeout(Duration.ofSeconds(5));
 
 	 	Iterable<EventData> drainedEvents =	datetimeReceiver.receiveSync(100);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverIdentifierTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverIdentifierTest.java
@@ -9,20 +9,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
 
-import com.microsoft.azure.eventhubs.QuotaExceededException;
+import com.microsoft.azure.eventhubs.*;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import com.microsoft.azure.eventhubs.EventHubClient;
-import com.microsoft.azure.eventhubs.PartitionReceiver;
-import com.microsoft.azure.eventhubs.ReceiverOptions;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.EventHubException;
 
 public class ReceiverIdentifierTest extends ApiTestBase {
 
@@ -50,11 +45,11 @@ public class ReceiverIdentifierTest extends ApiTestBase {
         for (int receiverCount = 0; receiverCount < 5; receiverCount ++) {
             final ReceiverOptions options = new ReceiverOptions();
             options.setIdentifier(receiverIdentifierPrefix + receiverCount);
-            ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.START_OF_STREAM, options);
+            ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromStartOfStream(), options);
         }
 
         try {
-            ehClient.createReceiverSync(cgName, partitionId, PartitionReceiver.START_OF_STREAM);
+            ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromStartOfStream());
             Assert.assertTrue(false);
         }
         catch (QuotaExceededException quotaError) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverRuntimeMetricsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiverRuntimeMetricsTest.java
@@ -44,9 +44,9 @@ public class ReceiverRuntimeMetricsTest  extends ApiTestBase {
         ReceiverOptions optionsWithMetricsDisabled = new ReceiverOptions();
         optionsWithMetricsDisabled.setReceiverRuntimeMetricEnabled(false);
 
-        receiverWithOptions = ehClient.createReceiverSync(cgName, partitionId, Instant.now(), options);
-        receiverWithoutOptions = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH);
-        receiverWithOptionsDisabled = ehClient.createReceiverSync(cgName, partitionId, Instant.EPOCH, optionsWithMetricsDisabled);
+        receiverWithOptions = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.now()), options);
+        receiverWithoutOptions = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH));
+        receiverWithOptionsDisabled = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.EPOCH), optionsWithMetricsDisabled);
         
         TestBase.pushEventsToPartition(ehClient, partitionId, sentEvents).get();
     }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SendTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SendTest.java
@@ -56,7 +56,7 @@ public class SendTest extends ApiTestBase
 		}
 		
 		final CompletableFuture<Void> validator = new CompletableFuture<>();
-		final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, Instant.now());
+		final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, partitionId, EventPosition.fromEnqueuedTime(Instant.now()));
 		this.receivers.add(receiver);
 		receiver.setReceiveTimeout(Duration.ofSeconds(1));
 		receiver.setReceiveHandler(new OrderValidator(validator, batchSize));
@@ -82,7 +82,7 @@ public class SendTest extends ApiTestBase
 		PartitionKeyValidator validator = new PartitionKeyValidator(validateSignal, partitionKey, 1);
 		for (int receiversCount=0; receiversCount < partitionCount; receiversCount++)
 		{
-			final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, Integer.toString(receiversCount), Instant.now());
+			final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, Integer.toString(receiversCount), EventPosition.fromEnqueuedTime(Instant.now()));
 			receivers.add(receiver);
                         
                         // run out of messages in that specific partition - to account for clock-skew with Instant.now() on test machine vs eventhubs service
@@ -109,7 +109,7 @@ public class SendTest extends ApiTestBase
 		PartitionKeyValidator validator = new PartitionKeyValidator(validateSignal, partitionKey, batchSize);
 		for (int receiversCount = 0; receiversCount < partitionCount; receiversCount++)
 		{
-			final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, Integer.toString(receiversCount), Instant.now());
+			final PartitionReceiver receiver = ehClient.createReceiverSync(cgName, Integer.toString(receiversCount), EventPosition.fromEnqueuedTime(Instant.now()));
 			receivers.add(receiver);
 			
                         // run out of messages in that specific partition - to account for clock-skew with Instant.now() on test machine vs eventhubs service


### PR DESCRIPTION
In this PR, I add the EventPosition abstraction and modify public APIs, `PartitionReceiver`, and all tests accordingly. I also update `PartitionReceiver` to allow for sequence number filtering. 

Note: this PR has breaking changes. All public APIs that take offsets or dateTimes have been removed.  