### PR TITLE
EventDataBatch can be sent without a partition key

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -383,7 +383,9 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
             throw new IllegalArgumentException("Empty batch of EventData cannot be sent.");
         }
 
-        return this.send(eventDatas.getInternalIterable(), eventDatas.getPartitionKey());
+        return eventDatas.getPartitionKey() != null ?
+                this.send(eventDatas.getInternalIterable(), eventDatas.getPartitionKey()) :
+                this.send(eventDatas.getInternalIterable());
     }
 
     /**


### PR DESCRIPTION
Minor bug fix - simply allowing event data batches to be sent even when a partition key isn't provided. 