### PR TITLE
ConnectionStringBuilder refactoring

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -304,10 +304,10 @@ public final class EventProcessorHost
     		{
     			// There is no entity path in the connection string, so put it there.
     			ConnectionStringBuilder rebuildCSB = new ConnectionStringBuilder()
-                    .setEndpoint(providedCSB.getEndpoint())
-                    .setEventHubName(this.eventHubPath)
-    				.setSasKeyName(providedCSB.getSasKeyName())
-                    .setSasKey(providedCSB.getSasKey());
+                        .setEndpoint(providedCSB.getEndpoint())
+                        .setEventHubName(this.eventHubPath)
+                        .setSasKeyName(providedCSB.getSasKeyName())
+                        .setSasKey(providedCSB.getSasKey());
     			rebuildCSB.setOperationTimeout(providedCSB.getOperationTimeout());
     			this.eventHubConnectionString = rebuildCSB.toString();
     		}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -303,8 +303,11 @@ public final class EventProcessorHost
     		else
     		{
     			// There is no entity path in the connection string, so put it there.
-    			ConnectionStringBuilder rebuildCSB = new ConnectionStringBuilder(providedCSB.getEndpoint(), this.eventHubPath,
-    					providedCSB.getSasKeyName(), providedCSB.getSasKey());
+    			ConnectionStringBuilder rebuildCSB = new ConnectionStringBuilder()
+                    .setEndpoint(providedCSB.getEndpoint())
+                    .setEntityPath(this.eventHubPath)
+    				.setSasKeyName(providedCSB.getSasKeyName())
+                    .setSasKey(providedCSB.getSasKey());
     			rebuildCSB.setOperationTimeout(providedCSB.getOperationTimeout());
     			this.eventHubConnectionString = rebuildCSB.toString();
     		}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -287,7 +287,7 @@ public final class EventProcessorHost
     	// The event hub path must appear in at least one of the eventHubPath argument or the connection string.
     	// If it appears in both, then it must be the same in both. If it appears in only one, populate the other.
     	ConnectionStringBuilder providedCSB = new ConnectionStringBuilder(eventHubConnectionString); 
-    	String extractedEntityPath = providedCSB.getEntityPath();
+    	String extractedEntityPath = providedCSB.getEventHubName();
         this.eventHubConnectionString = eventHubConnectionString;
     	if ((eventHubPath != null) && !eventHubPath.isEmpty())
     	{
@@ -305,7 +305,7 @@ public final class EventProcessorHost
     			// There is no entity path in the connection string, so put it there.
     			ConnectionStringBuilder rebuildCSB = new ConnectionStringBuilder()
                     .setEndpoint(providedCSB.getEndpoint())
-                    .setEntityPath(this.eventHubPath)
+                    .setEventHubName(this.eventHubPath)
     				.setSasKeyName(providedCSB.getSasKeyName())
                     .setSasKey(providedCSB.getSasKey());
     			rebuildCSB.setOperationTimeout(providedCSB.getOperationTimeout());

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/RealEventHubUtilities.java
@@ -6,32 +6,9 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.net.URLConnection;
-import java.nio.charset.StandardCharsets;
-import java.security.InvalidKeyException;
-import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Locale;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathExpressionException;
-import javax.xml.xpath.XPathFactory;
-
-import org.w3c.dom.Document;
-import org.w3c.dom.NodeList;
-import org.xml.sax.SAXException;
 
 import com.microsoft.azure.eventhubs.*;
 import com.microsoft.azure.eventhubs.EventHubException;
@@ -120,7 +97,7 @@ class RealEventHubUtilities
 		if (this.hubName == null)
 		{
 			this.hubConnectionString = new ConnectionStringBuilder(System.getenv("EVENT_HUB_CONNECTION_STRING"));
-			this.hubName = this.hubConnectionString.getEntityPath();
+			this.hubName = this.hubConnectionString.getEventHubName();
 		}
 	}
 	

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/Repros.java
@@ -42,7 +42,7 @@ public class Repros extends TestBase
 		
 		PrefabGeneralErrorHandler general1 = new PrefabGeneralErrorHandler();
 		PrefabProcessorFactory factory1 = new PrefabProcessorFactory(telltale, doCheckpointing, doMarker);
-		EventProcessorHost host1 = new EventProcessorHost(conflictingName, utils.getConnectionString().getEntityPath(),
+		EventProcessorHost host1 = new EventProcessorHost(conflictingName, utils.getConnectionString().getEventHubName(),
 				utils.getConsumerGroup(), utils.getConnectionString().toString(),
 				TestUtilities.getStorageConnectionString(), storageName);
 		EventProcessorOptions options1 = EventProcessorOptions.getDefaultOptions();
@@ -50,7 +50,7 @@ public class Repros extends TestBase
 		
 		PrefabGeneralErrorHandler general2 = new PrefabGeneralErrorHandler();
 		PrefabProcessorFactory factory2 = new PrefabProcessorFactory(telltale, doCheckpointing, doMarker);
-		EventProcessorHost host2 = new EventProcessorHost(conflictingName, utils.getConnectionString().getEntityPath(),
+		EventProcessorHost host2 = new EventProcessorHost(conflictingName, utils.getConnectionString().getEventHubName(),
 				utils.getConsumerGroup(), utils.getConnectionString().toString(),
 				TestUtilities.getStorageConnectionString(), storageName);
 		EventProcessorOptions options2 = EventProcessorOptions.getDefaultOptions();

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -46,7 +46,9 @@ public class TestBase
 			ConnectionStringBuilder replacedCSB = new ConnectionStringBuilder()
 					.setEndpoint(environmentCSB.getEndpoint())
 					.setEventHubName(
-							settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ? "" : settings.inoutEPHConstructorArgs.getEHPath()
+							settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ?
+                                    "" :
+                                    settings.inoutEPHConstructorArgs.getEHPath()
 					)
 					.setSasKeyName(environmentCSB.getSasKeyName())
 					.setSasKey(environmentCSB.getSasKey());

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -43,9 +43,13 @@ public class TestBase
 		if (settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_PATH_REPLACE_IN_CONNECTION) ||
 				settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH))
 		{
-			ConnectionStringBuilder replacedCSB = new ConnectionStringBuilder(environmentCSB.getEndpoint(),
-					settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ? "" : settings.inoutEPHConstructorArgs.getEHPath(), 
-					environmentCSB.getSasKeyName(), environmentCSB.getSasKey());
+			ConnectionStringBuilder replacedCSB = new ConnectionStringBuilder()
+					.setEndpoint(environmentCSB.getEndpoint())
+					.setEntityPath(
+							settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ? "" : settings.inoutEPHConstructorArgs.getEHPath()
+					)
+					.setSasKeyName(environmentCSB.getSasKeyName())
+					.setSasKey(environmentCSB.getSasKey());
 			replacedCSB.setOperationTimeout(environmentCSB.getOperationTimeout());
 			effectiveConnectionString = replacedCSB.toString();
 		}

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -34,7 +34,7 @@ public class TestBase
 		ConnectionStringBuilder environmentCSB = settings.outUtils.getConnectionString();
 
 		String effectiveEntityPath = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_PATH_OVERRIDE) ?
-				settings.inoutEPHConstructorArgs.getEHPath() : environmentCSB.getEntityPath();
+				settings.inoutEPHConstructorArgs.getEHPath() : environmentCSB.getEventHubName();
 				
 		String effectiveConsumerGroup = settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.CONSUMER_GROUP_OVERRIDE) ?
 				settings.inoutEPHConstructorArgs.getConsumerGroupName() : EventHubClient.DEFAULT_CONSUMER_GROUP_NAME; 
@@ -45,7 +45,7 @@ public class TestBase
 		{
 			ConnectionStringBuilder replacedCSB = new ConnectionStringBuilder()
 					.setEndpoint(environmentCSB.getEndpoint())
-					.setEntityPath(
+					.setEventHubName(
 							settings.inoutEPHConstructorArgs.isFlagSet(PerTestSettings.EPHConstructorArgs.EH_CONNECTION_REMOVE_PATH) ? "" : settings.inoutEPHConstructorArgs.getEHPath()
 					)
 					.setSasKeyName(environmentCSB.getSasKeyName())

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -8,179 +8,164 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
-import java.util.concurrent.Executor;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * {@link ConnectionStringBuilder} can be used to construct a connection string which can establish communication with ServiceBus entities.
- * It can also be used to perform basic validation on an existing connection string.
+ * {@link ConnectionStringBuilder} can be used to construct a connection string which can establish communication with Event Hub instances.
+ * In addition to constructing a connection string, the {@link ConnectionStringBuilder} can be used to modify an existing connection string.
  * <p> Sample Code:
  * <pre>{@code
- * 	ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(
- *     "ServiceBusNamespaceName",
- *     "ServiceBusEntityName", // eventHubName or QueueName or TopicName
- *     "SharedAccessSignatureKeyName",
- *     "SharedAccessSignatureKey");
+ *  // Construct a new connection string
+ * 	ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder()
+ * 	    .setNamespaceName("EventHubsNamespaceName")
+ *      .setEntityPath("EventHubsEntityName")
+ *      .setSasKeyName("SharedAccessSignatureKeyName")
+ *      .setSasKey("SharedAccessSignatureKey")
  *
- * String connectionString = connectionStringBuilder.toString();
+ *  string connString = connectionStringBuilder.build();
+ *
+ *  // Modify an existing connection string
+ *  ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(existingConnectionString)
+ *      .setEntityPath("SomeOtherEventHubsName")
+ *      .setOperationTimeout(Duration.ofSeconds(30)
+ *
+ *  string connString = connectionStringBuilder.build();
  * }</pre>
  * <p>
- * A connection string is basically a string consisted of key-value pair separated by ";".
- * Basic format is {{@literal <}key{@literal >}={@literal <}value{@literal >}[;{@literal <}key{@literal >}={@literal <}value{@literal >}]} where supported key name are as follow:
+ * A connection string is basically a string consisting of key-value pairs separated by ";".
+ * The basic format is {{@literal <}key{@literal >}={@literal <}value{@literal >}[;{@literal <}key{@literal >}={@literal <}value{@literal >}]} where supported key name are as follow:
  * <ul>
- * <li> Endpoint - the URL that contains the servicebus namespace
- * <li> EntityPath - the path to the service bus entity (queue/topic/eventhub/subscription/consumergroup/partition)
+ * <li> Endpoint - the URL that contains the EventHubs namespace
+ * <li> EntityPath - the EventHub name which you are connecting to
  * <li> SharedAccessKeyName - the key name to the corresponding shared access policy rule for the namespace, or entity.
  * <li> SharedAccessKey - the key for the corresponding shared access policy rule of the namespace or entity.
  * </ul>
  */
 public class ConnectionStringBuilder {
-    final static String endpointFormat = "amqps://%s.servicebus.windows.net";
-    final static String endpointRawFormat = "amqps://%s";
+    final static String endpointFormat = "sb://%s.%s";
+    final static String hostnameFormat = "sb://%s";
+    final static String defaultDomainName = "servicebus.windows.net";
 
-    final static String HostnameConfigName = "Hostname";
-    final static String EndpointConfigName = "Endpoint";
-    final static String SharedAccessKeyNameConfigName = "SharedAccessKeyName";
-    final static String SharedAccessKeyConfigName = "SharedAccessKey";
-    final static String SharedAccessSignatureConfigName = "SharedAccessSignature";
+    final static String HostnameConfigName = "Hostname";    // Hostname is a key that is used in IoTHub.
+    final static String EndpointConfigName = "Endpoint";    // Endpoint key is used in EventHubs. It's identical to Hostname in IoTHub.
     final static String EntityPathConfigName = "EntityPath";
     final static String OperationTimeoutConfigName = "OperationTimeout";
-    final static String RetryPolicyConfigName = "RetryPolicy";
     final static String KeyValueSeparator = "=";
     final static String KeyValuePairDelimiter = ";";
+    final static String SharedAccessKeyNameConfigName = "SharedAccessKeyName";  // We use a (KeyName, Key) pair OR the SAS token - never both.
+    final static String SharedAccessKeyConfigName = "SharedAccessKey";
+    final static String SharedAccessSignatureConfigName = "SharedAccessSignature";
 
     private static final String AllKeyEnumerateRegex = "(" + HostnameConfigName + "|" + EndpointConfigName + "|" + SharedAccessKeyNameConfigName
             + "|" + SharedAccessKeyConfigName + "|" + SharedAccessSignatureConfigName + "|" + EntityPathConfigName + "|" + OperationTimeoutConfigName
-            + "|" + RetryPolicyConfigName + ")";
+            + "|" + ")";
 
     private static final String KeysWithDelimitersRegex = KeyValuePairDelimiter + AllKeyEnumerateRegex
             + KeyValueSeparator;
 
     private URI endpoint;
+    private String eventHubName;
     private String sharedAccessKeyName;
     private String sharedAccessKey;
-    private String entityPath;
     private String sharedAccessSignature;
     private Duration operationTimeout;
-    private RetryPolicy retryPolicy;
-
-    private ConnectionStringBuilder(
-            final URI endpointAddress,
-            final String entityPath,
-            final String sharedAccessKeyName,
-            final String sharedAccessKey,
-            final Duration operationTimeout,
-            final RetryPolicy retryPolicy) {
-        this.endpoint = endpointAddress;
-        this.sharedAccessKey = sharedAccessKey;
-        this.sharedAccessKeyName = sharedAccessKeyName;
-        this.operationTimeout = operationTimeout;
-        this.retryPolicy = retryPolicy;
-        this.entityPath = entityPath;
-    }
-
-    private ConnectionStringBuilder(
-            final URI endpointAddress,
-            final String entityPath,
-            final String sharedAccessSignature,
-            final Duration operationTimeout,
-            final RetryPolicy retryPolicy) {
-        this.endpoint = endpointAddress;
-        this.sharedAccessSignature = sharedAccessSignature;
-        this.operationTimeout = operationTimeout;
-        this.retryPolicy = retryPolicy;
-        this.entityPath = entityPath;
-    }
-
-    private ConnectionStringBuilder(
-            final String namespaceName,
-            final String entityPath,
-            final String sharedAccessKeyName,
-            final String sharedAccessKey,
-            final Duration operationTimeout,
-            final RetryPolicy retryPolicy) {
-        try {
-            this.endpoint = new URI(String.format(Locale.US, endpointFormat, namespaceName));
-        } catch (URISyntaxException exception) {
-            throw new IllegalConnectionStringFormatException(
-                    String.format(Locale.US, "Invalid namespace name: %s", namespaceName),
-                    exception);
-        }
-
-        this.sharedAccessKey = sharedAccessKey;
-        this.sharedAccessKeyName = sharedAccessKeyName;
-        this.operationTimeout = operationTimeout;
-        this.retryPolicy = retryPolicy;
-        this.entityPath = entityPath;
-    }
 
     /**
-     * Build a connection string consumable by {@link com.microsoft.azure.eventhubs.EventHubClient#createFromConnectionString(String, Executor)}
+     * Creates an empty {@link ConnectionStringBuilder}. At minimum, a namespace name, an entity path, SAS key name, and SAS key
+     * need to be set before a valid connection string can be built.
      *
-     * @param namespaceName       Namespace name (dns suffix - ex: .servicebus.windows.net is not required)
-     * @param entityPath          Entity path. For eventHubs case specify - eventHub name.
-     * @param sharedAccessKeyName Shared Access Key name
-     * @param sharedAccessKey     Shared Access Key
+     * For advanced users, the following replacements can be done:
+     * <ul>
+     *     <li>An endpoint can be provided instead of a namespace name.</li>
+     *     <li>A SAS token can be provided instead of a SAS key name and SAS key.</li>
+     *     <li>Optionally, users can set an operation timeout instead of using the default value.</li>
+     * </ul>
      */
-    public ConnectionStringBuilder(
-            final String namespaceName,
-            final String entityPath,
-            final String sharedAccessKeyName,
-            final String sharedAccessKey) {
-        this(namespaceName, entityPath, sharedAccessKeyName, sharedAccessKey, MessagingFactory.DefaultOperationTimeout, RetryPolicy.getDefault());
-    }
-
-
-    /**
-     * Build a connection string consumable by {@link com.microsoft.azure.eventhubs.EventHubClient#createFromConnectionString(String, Executor)}
-     *
-     * @param endpointAddress     namespace level endpoint. This needs to be in the format of scheme://fullyQualifiedServiceBusNamespaceEndpointName
-     * @param entityPath          Entity path. For eventHubs case specify - eventHub name.
-     * @param sharedAccessKeyName Shared Access Key name
-     * @param sharedAccessKey     Shared Access Key
-     */
-    public ConnectionStringBuilder(
-            final URI endpointAddress,
-            final String entityPath,
-            final String sharedAccessKeyName,
-            final String sharedAccessKey) {
-        this(endpointAddress, entityPath, sharedAccessKeyName, sharedAccessKey, MessagingFactory.DefaultOperationTimeout, RetryPolicy.getDefault());
-    }
-
-    /**
-     * Build a connection string consumable by {@link com.microsoft.azure.eventhubs.EventHubClient#createFromConnectionString(String, Executor)}
-     *
-     * @param endpointAddress       namespace level endpoint. This needs to be in the format of scheme://fullyQualifiedServiceBusNamespaceEndpointName
-     * @param entityPath            Entity path. For eventHubs case specify - eventHub name.
-     * @param sharedAccessSignature Shared Access Signature
-     */
-    public ConnectionStringBuilder(
-            final URI endpointAddress,
-            final String entityPath,
-            final String sharedAccessSignature) {
-        this(endpointAddress, entityPath, sharedAccessSignature, MessagingFactory.DefaultOperationTimeout, RetryPolicy.getDefault());
-    }
+    public ConnectionStringBuilder() {}
 
     /**
      * ConnectionString format:
      * Endpoint=sb://namespace_DNS_Name;EntityPath=EVENT_HUB_NAME;SharedAccessKeyName=SHARED_ACCESS_KEY_NAME;SharedAccessKey=SHARED_ACCESS_KEY
      *
-     * @param connectionString ServiceBus ConnectionString
+     * @param connectionString EventHubs ConnectionString
      * @throws IllegalConnectionStringFormatException when the format of the ConnectionString is not valid
      */
     public ConnectionStringBuilder(String connectionString) {
-        this.parseConnectionString(connectionString);
+        parseConnectionString(connectionString);
     }
 
     /**
-     * Get the endpoint which can be used to connect to the ServiceBus Namespace
+     * Get the endpoint which can be used to connect to the EventHub instance.
      *
-     * @return Endpoint
+     * @return The currently set endpoint
      */
     public URI getEndpoint() {
         return this.endpoint;
+    }
+
+    /**
+     * Set an endpoint which can be used to connect to the EventHub instance.
+     *
+     * @param endpoint is a combination of the namespace name and domain name. Together, these pieces make a valid
+     *                 endpoint. For example, the default domain name is "servicebus.windows.net", so a sample endpoint
+     *                 would look like this: "sb://namespace_name.servicebus.windows.net".
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setEndpoint(URI endpoint) {
+        this.endpoint = endpoint;
+        return this;
+    }
+
+    /**
+     * Set an endpoint which can be used to connect to the EventHub instance.
+     *
+     * @param namespaceName the name of the namespace to connect to.
+     * @param domainName    identifies the domain the namespace is located in. To be used when connecting to
+     *                      non-public and international clouds.
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setEndpoint(String namespaceName, String domainName) {
+        try {
+            this.endpoint = new URI(String.format(Locale.US, endpointFormat, namespaceName, domainName));
+        } catch (URISyntaxException exception) {
+            throw new IllegalConnectionStringFormatException(
+                    String.format(Locale.US, "Invalid namespace name: %s", namespaceName),
+                    exception);
+        }
+        return this;
+    }
+
+    /**
+     * Set a namespace name which will be used to connect to an EventHubs instance. This method adds
+     * "servicebus.windows.net" as the default domain name.
+     *
+     * @param namespaceName the name of the namespace to connect to.
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setNamespaceName(String namespaceName) {
+        return this.setEndpoint(namespaceName, defaultDomainName);
+    }
+
+    /**
+     * Get the entity path value from the connection string.
+     *
+     * @return Entity Path
+     */
+    public String getEntityPath() {
+        return this.eventHubName;
+    }
+
+    /**
+     * Set the entity path value from the connection string.
+     *
+     * @param eventHubName the name of the Event Hub to connect to.
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setEntityPath(String eventHubName) {
+        this.eventHubName = eventHubName;
+        return this;
     }
 
     /**
@@ -193,12 +178,34 @@ public class ConnectionStringBuilder {
     }
 
     /**
+     * Set the shared access policy key value from the connection string
+     *
+     * @param sasKey the SAS key
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setSasKey(String sasKey) {
+        this.sharedAccessKey = sasKey;
+        return this;
+    }
+
+    /**
      * Get the shared access policy owner name from the connection string
      *
      * @return Shared Access Signature key name.
      */
     public String getSasKeyName() {
         return this.sharedAccessKeyName;
+    }
+
+    /**
+     * Set the shared access policy owner name from the connection string
+     *
+     * @param sasKeyName the SAS key name
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+    public ConnectionStringBuilder setSasKeyName(String sasKeyName) {
+        this.sharedAccessKeyName = sasKeyName;
+        return this;
     }
 
     /**
@@ -211,12 +218,14 @@ public class ConnectionStringBuilder {
     }
 
     /**
-     * Get the entity path value from the connection string
+     * Set the shared access signature (also referred as SAS Token) from the connection string
      *
-     * @return Entity Path
+     * @param sharedAccessSignature the shared access key signature
+     * @return the {@link ConnectionStringBuilder} being set.
      */
-    public String getEntityPath() {
-        return this.entityPath;
+    public ConnectionStringBuilder setSharedAccessSignature(String sharedAccessSignature) {
+        this.sharedAccessSignature = sharedAccessSignature;
+        return this;
     }
 
     /**
@@ -233,27 +242,38 @@ public class ConnectionStringBuilder {
      * <p>ConnectionString with operationTimeout is not inter-operable between java and clients in other platforms.
      *
      * @param operationTimeout Operation Timeout
+     * @return the {@link ConnectionStringBuilder} being set.
      */
-    public void setOperationTimeout(final Duration operationTimeout) {
+    public ConnectionStringBuilder setOperationTimeout(final Duration operationTimeout) {
         this.operationTimeout = operationTimeout;
+        return this;
     }
 
     /**
-     * Returns an inter-operable connection string that can be used to connect to ServiceBus Namespace
+     * Returns an inter-operable connection string that can be used to connect to EventHubs instances.
      *
      * @return connection string
      */
     @Override
     public String toString() {
+        return this.build();
+    }
+
+    /**
+     * Returns an inter-operable connection string that can be used to connect to EventHubs instances.
+     *
+     * @return connection string
+     */
+    public String build() {
         final StringBuilder connectionStringBuilder = new StringBuilder();
         if (this.endpoint != null) {
             connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", EndpointConfigName, KeyValueSeparator,
                     this.endpoint.toString(), KeyValuePairDelimiter));
         }
 
-        if (!StringUtil.isNullOrWhiteSpace(this.entityPath)) {
+        if (!StringUtil.isNullOrWhiteSpace(this.eventHubName)) {
             connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", EntityPathConfigName,
-                    KeyValueSeparator, this.entityPath, KeyValuePairDelimiter));
+                    KeyValueSeparator, this.eventHubName, KeyValuePairDelimiter));
         }
 
         if (!StringUtil.isNullOrWhiteSpace(this.sharedAccessKeyName)) {
@@ -276,18 +296,15 @@ public class ConnectionStringBuilder {
                     KeyValueSeparator, this.operationTimeout.toString(), KeyValuePairDelimiter));
         }
 
-        if (this.retryPolicy != null) {
-            connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", RetryPolicyConfigName,
-                    KeyValueSeparator, this.retryPolicy.toString(), KeyValuePairDelimiter));
-        }
-
         connectionStringBuilder.deleteCharAt(connectionStringBuilder.length() - 1);
         return connectionStringBuilder.toString();
     }
 
+
+
     private void parseConnectionString(final String connectionString) {
         if (StringUtil.isNullOrWhiteSpace(connectionString)) {
-            throw new IllegalConnectionStringFormatException(String.format("connectionString cannot be empty"));
+            throw new IllegalConnectionStringFormatException("connectionString cannot be empty");
         }
 
         final String connection = KeyValuePairDelimiter + connectionString;
@@ -339,7 +356,7 @@ public class ConnectionStringBuilder {
                 }
 
                 try {
-                    this.endpoint = new URI(String.format(Locale.US, endpointRawFormat, values[valueIndex]));
+                    this.endpoint = new URI(String.format(Locale.US, hostnameFormat, values[valueIndex]));
                 } catch (URISyntaxException exception) {
                     throw new IllegalConnectionStringFormatException(
                             String.format(Locale.US, "%s should be a fully quantified host name address", HostnameConfigName),
@@ -352,22 +369,13 @@ public class ConnectionStringBuilder {
             } else if (key.equalsIgnoreCase(SharedAccessSignatureConfigName)) {
                 this.sharedAccessSignature = values[valueIndex];
             } else if (key.equalsIgnoreCase(EntityPathConfigName)) {
-                this.entityPath = values[valueIndex];
+                this.eventHubName = values[valueIndex];
             } else if (key.equalsIgnoreCase(OperationTimeoutConfigName)) {
                 try {
                     this.operationTimeout = Duration.parse(values[valueIndex]);
                 } catch (DateTimeParseException exception) {
                     throw new IllegalConnectionStringFormatException("Invalid value specified for property 'Duration' in the ConnectionString.", exception);
                 }
-            } else if (key.equalsIgnoreCase(RetryPolicyConfigName)) {
-                this.retryPolicy = values[valueIndex].equals(ClientConstants.DEFAULT_RETRY)
-                        ? RetryPolicy.getDefault()
-                        : (values[valueIndex].equals(ClientConstants.NO_RETRY) ? RetryPolicy.getNoRetry() : null);
-
-                if (this.retryPolicy == null)
-                    throw new IllegalConnectionStringFormatException(
-                            String.format(Locale.US, "Connection string parameter '%s'='%s' is not recognized",
-                                    RetryPolicyConfigName, values[valueIndex]));
             } else {
                 throw new IllegalConnectionStringFormatException(
                         String.format(Locale.US, "Illegal connection string parameter name: %s", key));

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -20,9 +20,9 @@ import java.util.regex.Pattern;
  *  // Construct a new connection string
  * 	ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder()
  * 	    .setNamespaceName("EventHubsNamespaceName")
- *      .setEventHubName("EventHubsEntityName")
- *      .setSasKeyName("SharedAccessSignatureKeyName")
- *      .setSasKey("SharedAccessSignatureKey")
+ * 	    .setEventHubName("EventHubsEntityName")
+ * 	    .setSasKeyName("SharedAccessSignatureKeyName")
+ * 	    .setSasKey("SharedAccessSignatureKey")
  *
  *  string connString = connectionStringBuilder.build();
  *

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -259,15 +259,6 @@ public class ConnectionStringBuilder {
      */
     @Override
     public String toString() {
-        return this.build();
-    }
-
-    /**
-     * Returns an inter-operable connection string that can be used to connect to EventHubs instances.
-     *
-     * @return connection string
-     */
-    public String build() {
         final StringBuilder connectionStringBuilder = new StringBuilder();
         if (this.endpoint != null) {
             connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", EndpointConfigName, KeyValueSeparator,

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -20,7 +20,7 @@ import java.util.regex.Pattern;
  *  // Construct a new connection string
  * 	ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder()
  * 	    .setNamespaceName("EventHubsNamespaceName")
- *      .setEntityPath("EventHubsEntityName")
+ *      .setEventHubName("EventHubsEntityName")
  *      .setSasKeyName("SharedAccessSignatureKeyName")
  *      .setSasKey("SharedAccessSignatureKey")
  *
@@ -28,7 +28,7 @@ import java.util.regex.Pattern;
  *
  *  // Modify an existing connection string
  *  ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(existingConnectionString)
- *      .setEntityPath("SomeOtherEventHubsName")
+ *      .setEventHubName("SomeOtherEventHubsName")
  *      .setOperationTimeout(Duration.ofSeconds(30)
  *
  *  string connString = connectionStringBuilder.build();
@@ -122,8 +122,11 @@ public class ConnectionStringBuilder {
      * Set an endpoint which can be used to connect to the EventHub instance.
      *
      * @param namespaceName the name of the namespace to connect to.
-     * @param domainName    identifies the domain the namespace is located in. To be used when connecting to
-     *                      non-public and international clouds.
+     * @param domainName    identifies the domain the namespace is located in. For non-public and national clouds,
+     *                      the domain will not be "servicebus.windows.net". Available options include:
+     *                          - "servicebus.usgovcloudapi.net"
+     *                          - "servicebus.cloudapi.de"
+     *                          - "servicebus.chinacloudapi.cn"
      * @return the {@link ConnectionStringBuilder} being set.
      */
     public ConnectionStringBuilder setEndpoint(String namespaceName, String domainName) {
@@ -153,7 +156,7 @@ public class ConnectionStringBuilder {
      *
      * @return Entity Path
      */
-    public String getEntityPath() {
+    public String getEventHubName() {
         return this.eventHubName;
     }
 
@@ -163,7 +166,7 @@ public class ConnectionStringBuilder {
      * @param eventHubName the name of the Event Hub to connect to.
      * @return the {@link ConnectionStringBuilder} being set.
      */
-    public ConnectionStringBuilder setEntityPath(String eventHubName) {
+    public ConnectionStringBuilder setEventHubName(String eventHubName) {
         this.eventHubName = eventHubName;
         return this;
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -47,7 +47,7 @@ public class EventHubClient extends ClientEntity implements IEventHubClient {
     private EventHubClient(final ConnectionStringBuilder connectionString, final Executor executor) throws IOException, IllegalEntityException {
         super(StringUtil.getRandomString(), null, executor);
 
-        this.eventHubName = connectionString.getEntityPath();
+        this.eventHubName = connectionString.getEventHubName();
         this.senderCreateSync = new Object();
     }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
@@ -54,7 +54,7 @@ public class ConnStrBuilderTest extends ApiTestBase
 	{
 		final ConnectionStringBuilder connStrBuilder = new ConnectionStringBuilder(correctConnectionString);
 		final ConnectionStringBuilder secondConnStr = new ConnectionStringBuilder()
-				.setEndpoint(connStrBuilder.getEndpoint())
+                .setEndpoint(connStrBuilder.getEndpoint())
                 .setEventHubName(connStrBuilder.getEventHubName())
                 .setSasKeyName(connStrBuilder.getSasKeyName())
                 .setSasKey(connStrBuilder.getSasKey());

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
@@ -54,8 +54,11 @@ public class ConnStrBuilderTest extends ApiTestBase
 	public void exchangeConnectionStringAcrossConstructors()
 	{
 		final ConnectionStringBuilder connStrBuilder = new ConnectionStringBuilder(correctConnectionString);
-		final ConnectionStringBuilder secondConnStr = new ConnectionStringBuilder(connStrBuilder.getEndpoint(),
-				connStrBuilder.getEntityPath(), connStrBuilder.getSasKeyName(), connStrBuilder.getSasKey());
+		final ConnectionStringBuilder secondConnStr = new ConnectionStringBuilder()
+				.setEndpoint(connStrBuilder.getEndpoint())
+                .setEntityPath(connStrBuilder.getEntityPath())
+                .setSasKeyName(connStrBuilder.getSasKeyName())
+                .setSasKey(connStrBuilder.getSasKey());
 		secondConnStr.setOperationTimeout(connStrBuilder.getOperationTimeout());
 
 		validateConnStrBuilder.accept(new ConnectionStringBuilder(secondConnStr.toString()));

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
@@ -13,7 +13,6 @@ import org.junit.Test;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.IllegalConnectionStringFormatException;
-import com.microsoft.azure.eventhubs.RetryPolicy;
 
 public class ConnStrBuilderTest extends ApiTestBase
 {
@@ -23,7 +22,7 @@ public class ConnStrBuilderTest extends ApiTestBase
 		@Override
 		public void accept(ConnectionStringBuilder connStrBuilder)
 		{
-			Assert.assertTrue(connStrBuilder.getEntityPath().equals("eventhub1"));
+			Assert.assertTrue(connStrBuilder.getEventHubName().equals("eventhub1"));
 			Assert.assertTrue(connStrBuilder.getEndpoint().getHost().equals("endpoint1"));
 			Assert.assertTrue(connStrBuilder.getSasKey().equals("something"));
 			Assert.assertTrue(connStrBuilder.getSasKeyName().equals("somevalue"));
@@ -56,7 +55,7 @@ public class ConnStrBuilderTest extends ApiTestBase
 		final ConnectionStringBuilder connStrBuilder = new ConnectionStringBuilder(correctConnectionString);
 		final ConnectionStringBuilder secondConnStr = new ConnectionStringBuilder()
 				.setEndpoint(connStrBuilder.getEndpoint())
-                .setEntityPath(connStrBuilder.getEntityPath())
+                .setEventHubName(connStrBuilder.getEventHubName())
                 .setSasKeyName(connStrBuilder.getSasKeyName())
                 .setSasKey(connStrBuilder.getSasKey());
 		secondConnStr.setOperationTimeout(connStrBuilder.getOperationTimeout());

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/BackCompatTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/BackCompatTest.java
@@ -73,7 +73,7 @@ public class BackCompatTest extends ApiTestBase
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString, TestContext.EXECUTOR_SERVICE);
 		msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
 		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
-		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
+		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEventHubName() + "/partitions/" + partitionId).get();
 		
                 // until version 0.10.0 - we used to have Properties as HashMap<String,String> 
                 // This specific combination is intended to test the back compat - with the new Properties type as HashMap<String, Object>

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropAmqpPropertiesTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropAmqpPropertiesTest.java
@@ -100,7 +100,7 @@ public class InteropAmqpPropertiesTest extends ApiTestBase
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString, TestContext.EXECUTOR_SERVICE);
 		msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
 		receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
-		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
+		partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEventHubName() + "/partitions/" + partitionId).get();
 		partitionEventSender = ehClient.createPartitionSenderSync(partitionId);
 		
 		final HashMap<String, Object> appProperties = new HashMap<>();
@@ -137,7 +137,7 @@ public class InteropAmqpPropertiesTest extends ApiTestBase
 		msgReceiver = MessageReceiver.create(
 				msgFactory, 
 				"receiver1", 
-				connStrBuilder.getEntityPath() + "/ConsumerGroups/" + TestContext.getConsumerGroupName() + "/Partitions/" + partitionId,
+				connStrBuilder.getEventHubName() + "/ConsumerGroups/" + TestContext.getConsumerGroupName() + "/Partitions/" + partitionId,
 				100,
 				ehClient.createReceiver(TestContext.getConsumerGroupName(), partitionId, reSentAndReceivedEvent.getSystemProperties().getOffset(), false).get()).get();
                 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropEventBodyTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/InteropEventBodyTest.java
@@ -51,7 +51,7 @@ public class InteropEventBodyTest extends ApiTestBase {
         msgFactory = MessagingFactory.createFromConnectionString(connectionString, TestContext.EXECUTOR_SERVICE).get();
         receiver = ehClient.createReceiverSync(TestContext.getConsumerGroupName(), partitionId, Instant.now());
         partitionSender = ehClient.createPartitionSenderSync(partitionId);
-        partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEntityPath() + "/partitions/" + partitionId).get();
+        partitionMsgSender = MessageSender.create(msgFactory, "link1", connStrBuilder.getEventHubName() + "/partitions/" + partitionId).get();
         
         // run out of messages in that specific partition - to account for clock-skew with Instant.now() on test machine vs eventhubs service
         receiver.setReceiveTimeout(Duration.ofSeconds(5));

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
@@ -83,10 +83,10 @@ public class SecurityExceptionsTest extends ApiTestBase
                         correctConnectionString.getSasKey(),
                         String.format("amqps://%s/%s", correctConnectionString.getEndpoint().getHost(), correctConnectionString.getEventHubName()),
                         Duration.ofSeconds(10));
-                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
-					.setEndpoint(correctConnectionString.getEndpoint())
-					.setEventHubName(correctConnectionString.getEventHubName())
-					.setSharedAccessSignature(wrongToken);
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEventHubName(correctConnectionString.getEventHubName())
+				.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -101,10 +101,10 @@ public class SecurityExceptionsTest extends ApiTestBase
                         correctConnectionString.getSasKey(),
                         "----------wrongresource-----------",
                         Duration.ofSeconds(10));
-                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
-					.setEndpoint(correctConnectionString.getEndpoint())
-					.setEventHubName(correctConnectionString.getEventHubName())
-					.setSharedAccessSignature(wrongToken);
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEventHubName(correctConnectionString.getEventHubName())
+				.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
@@ -24,11 +24,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testEventHubClientUnAuthorizedAccessKeyName() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				"---------------wrongkey------------",
-				correctConnectionString.getSasKey());
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSasKeyName("---------------wrongkey------------")
+				.setSasKey(correctConnectionString.getSasKey());
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -38,11 +38,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testEventHubClientUnAuthorizedAccessKey() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				correctConnectionString.getSasKeyName(),
-				"--------------wrongvalue-----------");
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSasKeyName(correctConnectionString.getSasKeyName())
+				.setSasKey("--------------wrongvalue-----------");
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -52,10 +52,10 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testEventHubClientInvalidAccessToken() throws Throwable
 	{
                 final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				"--------------invalidtoken-------------");
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSharedAccessSignature("--------------invalidtoken-------------");
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -65,10 +65,10 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testEventHubClientNullAccessToken() throws Throwable
 	{
                 final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				null);
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSharedAccessSignature(null);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -83,10 +83,10 @@ public class SecurityExceptionsTest extends ApiTestBase
                         correctConnectionString.getSasKey(),
                         String.format("amqps://%s/%s", correctConnectionString.getEndpoint().getHost(), correctConnectionString.getEntityPath()),
                         Duration.ofSeconds(10));
-                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				wrongToken);
+                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+					.setEndpoint(correctConnectionString.getEndpoint())
+					.setEntityPath(correctConnectionString.getEntityPath())
+					.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -101,10 +101,10 @@ public class SecurityExceptionsTest extends ApiTestBase
                         correctConnectionString.getSasKey(),
                         "----------wrongresource-----------",
                         Duration.ofSeconds(10));
-                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				wrongToken);
+                final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+					.setEndpoint(correctConnectionString.getEndpoint())
+					.setEntityPath(correctConnectionString.getEntityPath())
+					.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("Test Message".getBytes()));
@@ -114,11 +114,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testUnAuthorizedAccessSenderCreation() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				"---------------wrongkey------------",
-				correctConnectionString.getSasKey());
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSasKeyName("------------wrongkeyname----------")
+				.setSasKey(correctConnectionString.getSasKey());
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.createPartitionSenderSync(PARTITION_ID);
@@ -128,11 +128,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testUnAuthorizedAccessReceiverCreation() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				correctConnectionString.getEntityPath(),
-				"---------------wrongkey------------",
-				correctConnectionString.getSasKey());
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath(correctConnectionString.getEntityPath())
+				.setSasKeyName("---------------wrongkey------------")
+				.setSasKey(correctConnectionString.getSasKey());
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, PartitionReceiver.START_OF_STREAM);
@@ -142,11 +142,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testSendToNonExistantEventHub() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				"non-existant-entity" + UUID.randomUUID().toString(),
-				correctConnectionString.getSasKeyName(),
-				correctConnectionString.getSasKey());
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath("non-existant-entity" + UUID.randomUUID().toString())
+				.setSasKeyName(correctConnectionString.getSasKeyName())
+				.setSasKey(correctConnectionString.getSasKey());
 
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.sendSync(new EventData("test string".getBytes()));
@@ -156,11 +156,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 	public void testReceiveFromNonExistantEventHub() throws Throwable
 	{
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
-		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder(
-				correctConnectionString.getEndpoint(),
-				"non-existant-entity" + UUID.randomUUID().toString(),
-				correctConnectionString.getSasKeyName(),
-				correctConnectionString.getSasKey());
+		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
+				.setEndpoint(correctConnectionString.getEndpoint())
+				.setEntityPath("non-existant-entity" + UUID.randomUUID().toString())
+				.setSasKeyName(correctConnectionString.getSasKeyName())
+				.setSasKey(correctConnectionString.getSasKey());
 
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
 		ehClient.createReceiverSync(TestContext.getConsumerGroupName(), PARTITION_ID, PartitionReceiver.START_OF_STREAM);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SecurityExceptionsTest.java
@@ -26,7 +26,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSasKeyName("---------------wrongkey------------")
 				.setSasKey(correctConnectionString.getSasKey());
 		
@@ -40,7 +40,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSasKeyName(correctConnectionString.getSasKeyName())
 				.setSasKey("--------------wrongvalue-----------");
 		
@@ -54,7 +54,7 @@ public class SecurityExceptionsTest extends ApiTestBase
                 final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSharedAccessSignature("--------------invalidtoken-------------");
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
@@ -67,7 +67,7 @@ public class SecurityExceptionsTest extends ApiTestBase
                 final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSharedAccessSignature(null);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
@@ -81,11 +81,11 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final String wrongToken = SharedAccessSignatureTokenProvider.generateSharedAccessSignature(
                         "wrongkey",
                         correctConnectionString.getSasKey(),
-                        String.format("amqps://%s/%s", correctConnectionString.getEndpoint().getHost(), correctConnectionString.getEntityPath()),
+                        String.format("amqps://%s/%s", correctConnectionString.getEndpoint().getHost(), correctConnectionString.getEventHubName()),
                         Duration.ofSeconds(10));
                 final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 					.setEndpoint(correctConnectionString.getEndpoint())
-					.setEntityPath(correctConnectionString.getEntityPath())
+					.setEventHubName(correctConnectionString.getEventHubName())
 					.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
@@ -103,7 +103,7 @@ public class SecurityExceptionsTest extends ApiTestBase
                         Duration.ofSeconds(10));
                 final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 					.setEndpoint(correctConnectionString.getEndpoint())
-					.setEntityPath(correctConnectionString.getEntityPath())
+					.setEventHubName(correctConnectionString.getEventHubName())
 					.setSharedAccessSignature(wrongToken);
 		
 		ehClient = EventHubClient.createFromConnectionStringSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
@@ -116,7 +116,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSasKeyName("------------wrongkeyname----------")
 				.setSasKey(correctConnectionString.getSasKey());
 		
@@ -130,7 +130,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath(correctConnectionString.getEntityPath())
+				.setEventHubName(correctConnectionString.getEventHubName())
 				.setSasKeyName("---------------wrongkey------------")
 				.setSasKey(correctConnectionString.getSasKey());
 		
@@ -144,7 +144,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath("non-existant-entity" + UUID.randomUUID().toString())
+				.setEventHubName("non-existant-entity" + UUID.randomUUID().toString())
 				.setSasKeyName(correctConnectionString.getSasKeyName())
 				.setSasKey(correctConnectionString.getSasKey());
 
@@ -158,7 +158,7 @@ public class SecurityExceptionsTest extends ApiTestBase
 		final ConnectionStringBuilder correctConnectionString = TestContext.getConnectionString();
 		final ConnectionStringBuilder connectionString = new ConnectionStringBuilder()
 				.setEndpoint(correctConnectionString.getEndpoint())
-				.setEntityPath("non-existant-entity" + UUID.randomUUID().toString())
+				.setEventHubName("non-existant-entity" + UUID.randomUUID().toString())
 				.setSasKeyName(correctConnectionString.getSasKeyName())
 				.setSasKey(correctConnectionString.getSasKey());
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
@@ -21,14 +21,16 @@ public class SasTokenTestBase extends ApiTestBase {
     public static void replaceConnectionString()  throws Exception {
         
         originalConnectionString = TestContext.getConnectionString();
-        final String connectionStringWithSasToken = new ConnectionStringBuilder(
-                    originalConnectionString.getEndpoint(),
-                    originalConnectionString.getEntityPath(),
+        final String connectionStringWithSasToken = new ConnectionStringBuilder()
+                .setEndpoint(originalConnectionString.getEndpoint())
+                .setEntityPath(originalConnectionString.getEntityPath())
+                .setSharedAccessSignature(
                     SharedAccessSignatureTokenProvider.generateSharedAccessSignature(originalConnectionString.getSasKeyName(),
                             originalConnectionString.getSasKey(), 
                             String.format("amqp://%s/%s", originalConnectionString.getEndpoint().getHost(), originalConnectionString.getEntityPath()),
-                            Duration.ofDays(1)))
-                    .toString();
+                            Duration.ofDays(1))
+                )
+                .build();
 
         TestContext.setConnectionString(connectionStringWithSasToken);
     }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
@@ -30,7 +30,7 @@ public class SasTokenTestBase extends ApiTestBase {
                             String.format("amqp://%s/%s", originalConnectionString.getEndpoint().getHost(), originalConnectionString.getEventHubName()),
                             Duration.ofDays(1))
                 )
-                .build();
+                .toString();
 
         TestContext.setConnectionString(connectionStringWithSasToken);
     }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/SasTokenTestBase.java
@@ -23,11 +23,11 @@ public class SasTokenTestBase extends ApiTestBase {
         originalConnectionString = TestContext.getConnectionString();
         final String connectionStringWithSasToken = new ConnectionStringBuilder()
                 .setEndpoint(originalConnectionString.getEndpoint())
-                .setEntityPath(originalConnectionString.getEntityPath())
+                .setEventHubName(originalConnectionString.getEventHubName())
                 .setSharedAccessSignature(
                     SharedAccessSignatureTokenProvider.generateSharedAccessSignature(originalConnectionString.getSasKeyName(),
                             originalConnectionString.getSasKey(), 
-                            String.format("amqp://%s/%s", originalConnectionString.getEndpoint().getHost(), originalConnectionString.getEntityPath()),
+                            String.format("amqp://%s/%s", originalConnectionString.getEndpoint().getHost(), originalConnectionString.getEventHubName()),
                             Duration.ofDays(1))
                 )
                 .build();

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -115,7 +115,7 @@ public class RequestResponseTest  extends ApiTestBase {
             final Message request= Proton.message();
             final Map<String, String> properties = new HashMap<>();
             properties.put(ClientConstants.MANAGEMENT_ENTITY_TYPE_KEY, ClientConstants.MANAGEMENT_EVENTHUB_ENTITY_TYPE);
-            properties.put(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY, connectionString.getEntityPath());
+            properties.put(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY, connectionString.getEventHubName());
             properties.put(ClientConstants.MANAGEMENT_OPERATION_KEY, ClientConstants.READ_OPERATION_VALUE);
             final ApplicationProperties applicationProperties = new ApplicationProperties(properties);
             request.setApplicationProperties(applicationProperties);
@@ -147,7 +147,7 @@ public class RequestResponseTest  extends ApiTestBase {
                                         this.onError(new AmqpException(error));
                                     }
 
-                                    if (connectionString.getEntityPath().equalsIgnoreCase((String) resultMap.get(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY)))
+                                    if (connectionString.getEventHubName().equalsIgnoreCase((String) resultMap.get(ClientConstants.MANAGEMENT_ENTITY_NAME_KEY)))
                                         task.complete(null);
                                     else
                                         task.completeExceptionally(new AssertionFailedError("response doesn't have correct eventhub name"));
@@ -198,7 +198,7 @@ public class RequestResponseTest  extends ApiTestBase {
     	EventHubRuntimeInformation ehInfo = ehc.getRuntimeInformation().get();
 
     	Assert.assertNotNull(ehInfo);
-    	Assert.assertTrue(connectionString.getEntityPath().equalsIgnoreCase(ehInfo.getPath()));
+    	Assert.assertTrue(connectionString.getEventHubName().equalsIgnoreCase(ehInfo.getPath()));
     	Assert.assertNotNull(ehInfo.getCreatedAt()); // creation time could be almost anything, can't really check value
     	Assert.assertTrue(ehInfo.getPartitionCount() >= 2); // max legal partition count is variable but 2 is hard minimum
     	Assert.assertEquals(ehInfo.getPartitionIds().length, ehInfo.getPartitionCount());
@@ -218,7 +218,7 @@ public class RequestResponseTest  extends ApiTestBase {
 	    	EventHubPartitionRuntimeInformation partInfo = ehc.getPartitionRuntimeInformation(id).get();
 	    	
 	    	Assert.assertNotNull(partInfo);
-	    	Assert.assertTrue(connectionString.getEntityPath().equalsIgnoreCase(partInfo.getEventHubPath()));
+	    	Assert.assertTrue(connectionString.getEventHubName().equalsIgnoreCase(partInfo.getEventHubPath()));
 	    	Assert.assertTrue(id.equalsIgnoreCase(partInfo.getPartitionId()));
 	    	Assert.assertTrue(partInfo.getBeginSequenceNumber() >= -1);
 	    	Assert.assertTrue(partInfo.getLastEnqueuedSequenceNumber() >= -1);
@@ -243,7 +243,7 @@ public class RequestResponseTest  extends ApiTestBase {
     public void testGetRuntimesBadHub() throws EventHubException, IOException {
     	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder()
                 .setEndpoint(connectionString.getEndpoint())
-                .setEntityPath("NOHUBZZZZZ")
+                .setEventHubName("NOHUBZZZZZ")
                 .setSasKeyName(connectionString.getSasKeyName())
                 .setSasKey(connectionString.getSasKey());
     	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);
@@ -297,7 +297,7 @@ public class RequestResponseTest  extends ApiTestBase {
     public void testGetRuntimesBadKeyname() throws EventHubException, IOException {
     	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder()
                 .setEndpoint(connectionString.getEndpoint())
-                .setEntityPath(connectionString.getEntityPath())
+                .setEventHubName(connectionString.getEventHubName())
                 .setSasKeyName("xxxnokeyxxx")
                 .setSasKey(connectionString.getSasKey());
     	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -246,7 +246,7 @@ public class RequestResponseTest  extends ApiTestBase {
                 .setEventHubName("NOHUBZZZZZ")
                 .setSasKeyName(connectionString.getSasKeyName())
                 .setSasKey(connectionString.getSasKey());
-    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);
+    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString(), TestContext.EXECUTOR_SERVICE);
     	
     	try {
     		ehc.getRuntimeInformation().get();
@@ -300,7 +300,7 @@ public class RequestResponseTest  extends ApiTestBase {
                 .setEventHubName(connectionString.getEventHubName())
                 .setSasKeyName("xxxnokeyxxx")
                 .setSasKey(connectionString.getSasKey());
-    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);
+    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString(), TestContext.EXECUTOR_SERVICE);
     	
     	try {
     		ehc.getRuntimeInformation().get();

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -241,9 +241,12 @@ public class RequestResponseTest  extends ApiTestBase {
     
     @Test
     public void testGetRuntimesBadHub() throws EventHubException, IOException {
-    	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder(connectionString.getEndpoint(), "NOHUBZZZZZ",
-    			connectionString.getSasKeyName(), connectionString.getSasKey());
-    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString(), TestContext.EXECUTOR_SERVICE);
+    	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder()
+                .setEndpoint(connectionString.getEndpoint())
+                .setEntityPath("NOHUBZZZZZ")
+                .setSasKeyName(connectionString.getSasKeyName())
+                .setSasKey(connectionString.getSasKey());
+    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);
     	
     	try {
     		ehc.getRuntimeInformation().get();
@@ -292,9 +295,12 @@ public class RequestResponseTest  extends ApiTestBase {
     
     @Test
     public void testGetRuntimesBadKeyname() throws EventHubException, IOException {
-    	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder(connectionString.getEndpoint(), connectionString.getEntityPath(),
-    			"xxxnokeyxxx", connectionString.getSasKey());
-    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.toString(), TestContext.EXECUTOR_SERVICE);
+    	ConnectionStringBuilder bogusConnectionString = new ConnectionStringBuilder()
+                .setEndpoint(connectionString.getEndpoint())
+                .setEntityPath(connectionString.getEntityPath())
+                .setSasKeyName("xxxnokeyxxx")
+                .setSasKey(connectionString.getSasKey());
+    	EventHubClient ehc = EventHubClient.createFromConnectionStringSync(bogusConnectionString.build(), TestContext.EXECUTOR_SERVICE);
     	
     	try {
     		ehc.getRuntimeInformation().get();


### PR DESCRIPTION
In this PR I modified `ConnectionStringBuilder` to have setters and getters to construct/modify the connection string. This resulted in the removal of existing constructors. 

Note: this PR has breaking changes. 