### PR TITLE
Restore EventProcessorHost.getHostName API

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -321,6 +321,15 @@ public final class EventProcessorHost
         TRACE_LOGGER.info(this.hostContext.withHost("New EventProcessorHost created."));
     }
 
+    /**
+     * The processor host name is supplied by the user at constructor time, but being able to get
+     * it is useful because it means not having to carry both the host object and the name around.
+     * As long as you have the host object, you can get the name back, such as for logging.
+     * 
+     * @return	The processor host name
+     */
+    public String getHostName() { return this.hostContext.getHostName(); }
+    
     // TEST USE ONLY
     void setPartitionManager(PartitionManager pm) { this.partitionManager = pm; }
     HostContext getHostContext() { return this.hostContext; }


### PR DESCRIPTION
## Description

Restore EventProcessorHost.getHostName API which was removed during the doc sweep as unneeded but turns out to still be useful.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.