### PR TITLE
EventDataBatch BufferOverflow fix

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
@@ -46,7 +46,7 @@ public final class EventDataBatch {
      * @param eventData The {@link EventData} to add.
      * @return A boolean value indicating if the {@link EventData} addition to this batch/collection was successful or not.
      */
-    public final boolean tryAdd(final EventData eventData) {
+    public final boolean tryAdd(final EventData eventData) throws PayloadSizeExceededException {
 
         if (eventData == null) {
             throw new IllegalArgumentException("eventData cannot be null");
@@ -56,7 +56,7 @@ public final class EventDataBatch {
         try {
             size = getSize(eventData, events.isEmpty());
         } catch (java.nio.BufferOverflowException exception) {
-            return false;
+            throw new PayloadSizeExceededException(String.format("Size of the payload exceeded Maximum message size: %s kb", this.maxMessageSize / 1024));
         }
 
         if (this.currentSize + size > this.maxMessageSize)

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventDataBatch.java
@@ -52,7 +52,13 @@ public final class EventDataBatch {
             throw new IllegalArgumentException("eventData cannot be null");
         }
 
-        final int size = getSize(eventData, events.isEmpty());
+        final int size;
+        try {
+            size = getSize(eventData, events.isEmpty());
+        } catch (java.nio.BufferOverflowException exception) {
+            return false;
+        }
+
         if (this.currentSize + size > this.maxMessageSize)
             return false;
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs.eventdata;
+
+import com.microsoft.azure.eventhubs.*;
+import com.microsoft.azure.eventhubs.lib.ApiTestBase;
+import com.microsoft.azure.eventhubs.lib.TestContext;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.Executors;
+
+public class EventDataBatchTest extends ApiTestBase {
+
+   private static EventHubClient ehClient;
+
+   @Test(expected = PayloadSizeExceededException.class)
+   public void payloadExceededException() throws EventHubException, IOException {
+      final ConnectionStringBuilder connStrBuilder = TestContext.getConnectionString();
+      ehClient = EventHubClient.createFromConnectionStringSync(connStrBuilder.toString(), Executors.newSingleThreadExecutor());
+
+      final EventDataBatch batch = ehClient.createBatch();
+
+      final EventData within = new EventData(new byte[1024]);
+      final EventData tooBig = new EventData(new byte[1024 * 500]);
+
+      Assert.assertTrue(batch.tryAdd(within));
+      batch.tryAdd(tooBig);
+   }
+}


### PR DESCRIPTION
Close #235 

When `getSize` results in a buffer overflow (i.e. when the provided `EventData` is higher than the `maxMessageSize`), we throw a `PayloadSizeExceededException`. 