### PR TITLE
Fix issues in javadocs where > and < symbols have been used, resulting in javadoc errors.

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -367,7 +367,7 @@ public final class EventProcessorHost
      * <pre>
      * class MyEventProcessor implements IEventProcessor { ... }
      * EventProcessorHost host = new EventProcessorHost(...);
-     * CompletableFuture<Void> foo = host.registerEventProcessor(MyEventProcessor.class);
+     * CompletableFuture&lt;Void&gt; foo = host.registerEventProcessor(MyEventProcessor.class);
      * foo.get();
      * </pre>
      *  

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -27,21 +27,21 @@ public interface ICheckpointManager
 	 * The returned CompletableFuture completes with true if the checkpoint store exists or false if it
 	 * does not. It completes exceptionally on error.
 	 * 
-	 * @return CompletableFuture -> true if it exists, false if not
+	 * @return CompletableFuture -&gt; true if it exists, false if not
 	 */
     public CompletableFuture<Boolean> checkpointStoreExists();
 
     /***
      * Create the checkpoint store if it doesn't exist. Do nothing if it does exist.
      * 
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> createCheckpointStoreIfNotExists();
     
     /**
      * Deletes the checkpoint store.
      * 
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> deleteCheckpointStore();
 
@@ -51,7 +51,7 @@ public interface ICheckpointManager
      * 
      * @param partitionId  Id of partition to get checkpoint info for.
      * 
-     * @return  CompletableFuture -> checkpoint info, or null. Completes exceptionally on error.
+     * @return  CompletableFuture -&gt; checkpoint info, or null. Completes exceptionally on error.
      */
     public CompletableFuture<Checkpoint> getCheckpoint(String partitionId);
     
@@ -67,7 +67,7 @@ public interface ICheckpointManager
      * a checkpoint (storing an offset/sequence number pair in the structure).
      * 
      * @param partitionId  Id of partition to create the checkpoint HOLDER for.
-     * @return CompletableFuture -> the checkpoint for the given partition, if one exists, or null. Completes exceptionally on error.
+     * @return CompletableFuture -&gt; the checkpoint for the given partition, if one exists, or null. Completes exceptionally on error.
      */
     public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId);
 
@@ -81,7 +81,7 @@ public interface ICheckpointManager
      * 
      * @param lease		  lease for the partition to be checkpointed.
      * @param checkpoint  offset/sequenceNumber and partition id to update the store with.
-     * @return CompletableFuture -> null on success. Completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success. Completes exceptionally on error.
      */
     public CompletableFuture<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint);
     
@@ -91,7 +91,7 @@ public interface ICheckpointManager
      * your implementation is free to do whichever is more convenient. 
      * 
      * @param partitionId  id of partition to delete checkpoint from store
-     * @return CompletableFuture -> null on success. Completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success. Completes exceptionally on error.
      */
     public CompletableFuture<Void> deleteCheckpoint(String partitionId);
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
@@ -46,28 +46,28 @@ public interface ILeaseManager
 	 * The returned CompletableFuture completes with true if the checkpoint store exists or false if it
 	 * does not. It completes exceptionally on error.
 	 * 
-	 * @return CompletableFuture -> true if it exists, false if not
+	 * @return CompletableFuture -&gt; true if it exists, false if not
 	 */
     public CompletableFuture<Boolean> leaseStoreExists();
 
     /**
      * Create the lease store if it does not exist, do nothing if it does exist.
      * 
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> createLeaseStoreIfNotExists();
     
     /**
      * Deletes the lease store.
      * 
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> deleteLeaseStore();
     
     /**
      * Returns the lease info for all partitions.
      * 
-     * @return  CompletableFuture -> list of Leases, completes exceptionally on error.
+     * @return  CompletableFuture -&gt; list of Leases, completes exceptionally on error.
      */
     public CompletableFuture<List<Lease>> getAllLeases();
 
@@ -76,7 +76,7 @@ public interface ILeaseManager
      * in the store already.
      * 
      * @param partitionId  id of partition to create lease info for
-     * @return CompletableFuture -> the existing or newly-created lease info for the partition, completes exceptionally on error
+     * @return CompletableFuture -&gt; the existing or newly-created lease info for the partition, completes exceptionally on error
      */
     public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId);
 
@@ -85,7 +85,7 @@ public interface ILeaseManager
      * that is treated as success.
      *  
      * @param lease  the currently existing lease info for the partition
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> deleteLease(Lease lease);
 
@@ -102,7 +102,7 @@ public interface ILeaseManager
      * throwing an access exception, which is an error and should complete exceptionally. 
      * 
      * @param lease  Lease info for the desired partition
-     * @return  CompletableFuture -> true if the lease was acquired, false if not, completes exceptionally on error. 
+     * @return  CompletableFuture -&gt; true if the lease was acquired, false if not, completes exceptionally on error.
      */
     public CompletableFuture<Boolean> acquireLease(Lease lease);
 
@@ -126,7 +126,7 @@ public interface ILeaseManager
      * has been fulfilled.
      * 
      * @param lease  Lease to be given up
-     * @return CompletableFuture -> null on success, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> releaseLease(Lease lease);
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
@@ -173,7 +173,7 @@ public class Lease
      * A class derived from Lease should override this function to inspect the lease and return whether it has expired.
      * Uses CompletableFuture because determining whether a lease is expired may involve I/O.
      *  
-     * @return CompletableFuture -> true if the lease is expired, false if it is still valid, completes exceptionally on error.
+     * @return CompletableFuture -&gt; true if the lease is expired, false if it is still valid, completes exceptionally on error.
      */
     public CompletableFuture<Boolean> isExpired()
     {

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -167,7 +167,7 @@ public class PartitionContext
      * then this will fail. (This scenario is possible when invoke-after-receive-timeout has been set
      * in EventProcessorOptions.)
      * 
-     * @return CompletableFuture -> null when the checkpoint has been persisted successfully, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null when the checkpoint has been persisted successfully, completes exceptionally on error.
      */
     public CompletableFuture<Void> checkpoint()
     {
@@ -191,7 +191,7 @@ public class PartitionContext
      * It is important to check the result in order to detect failures.
      *  
      * @param event  A received EventData
-     * @return CompletableFuture -> null when the checkpoint has been persisted successfully, completes exceptionally on error.
+     * @return CompletableFuture -&gt; null when the checkpoint has been persisted successfully, completes exceptionally on error.
      */
     public CompletableFuture<Void> checkpoint(EventData event)
     {


### PR DESCRIPTION
A number of JavaDoc issues were recently introduced, resulting in build failures for JavaDocs when running `mvn javadoc:aggregate`. This pull request fixes these.