### PR TITLE
Fix PartitionManager.stopPartitions

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -29,7 +29,7 @@ class PartitionManager
 {
 	// Protected instead of private for testability
     protected final HostContext hostContext;
-    protected Pump pump;
+    protected Pump pump = null;
     protected volatile String partitionIds[] = null;
     
     final private Object scanFutureSynchronizer = new Object(); 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -131,23 +131,31 @@ class PartitionManager
     	}
 
     	// Stop any partition pumps that are running.
-    	TRACE_LOGGER.info(this.hostContext.withHost("Shutting down all pumps"));
-    	CompletableFuture<?>[] pumpRemovals = this.pump.removeAllPumps(CloseReason.Shutdown);
-    	return CompletableFuture.allOf(pumpRemovals).whenCompleteAsync((empty, e) ->
+    	CompletableFuture<Void> retval = CompletableFuture.completedFuture(null);
+    	
+    	if (this.pump != null)
     	{
-    		if (e != null)
-    		{
-    			Throwable notifyWith = LoggingUtils.unwrapException(e, null);
-    			TRACE_LOGGER.warn(this.hostContext.withHost("Failure during shutdown"), notifyWith);
-    			if (notifyWith instanceof Exception)
-    			{
-    				this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), (Exception) notifyWith,
-    						EventProcessorHostActionStrings.PARTITION_MANAGER_CLEANUP);
-
-    			}
-    		}
-	        TRACE_LOGGER.info(this.hostContext.withHost("Partition manager exiting"));
-    	}, this.hostContext.getExecutor());
+	    	TRACE_LOGGER.info(this.hostContext.withHost("Shutting down all pumps"));
+	    	CompletableFuture<?>[] pumpRemovals = this.pump.removeAllPumps(CloseReason.Shutdown);
+	    	retval = CompletableFuture.allOf(pumpRemovals).whenCompleteAsync((empty, e) ->
+	    	{
+	    		if (e != null)
+	    		{
+	    			Throwable notifyWith = LoggingUtils.unwrapException(e, null);
+	    			TRACE_LOGGER.warn(this.hostContext.withHost("Failure during shutdown"), notifyWith);
+	    			if (notifyWith instanceof Exception)
+	    			{
+	    				this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), (Exception) notifyWith,
+	    						EventProcessorHostActionStrings.PARTITION_MANAGER_CLEANUP);
+	
+	    			}
+	    		}
+		        TRACE_LOGGER.info(this.hostContext.withHost("Partition manager exiting"));
+	    	}, this.hostContext.getExecutor());
+    	}
+    	// else no pumps to shut down
+    	
+    	return retval;
     }
     
     public CompletableFuture<Void> initialize()


### PR DESCRIPTION
## Description

PartitionManager.stopPartitions should be a no-op and not throw if initialize was never called.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.