### PR TITLE
Add public method checkpoint(Checkpoint) to PartitionContext

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -197,7 +197,20 @@ public class PartitionContext
     {
     	return persistCheckpoint(new Checkpoint(this.partitionId, event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber()));
     }
-    
+
+    /**
+     * Writes the position of the provided Checkpoint instance to the checkpoint store via the checkpoint manager.
+     *
+     * It is important to check the result in order to detect failures.
+     *
+     * @param checkpoint  a checkpoint
+     * @return CompletableFuture {@literal ->} null when the checkpoint has been persisted successfully, completes exceptionally on error.
+     */
+    public CompletableFuture<Void> checkpoint(Checkpoint checkpoint)
+    {
+        return persistCheckpoint(checkpoint);
+    }
+
     private CompletableFuture<Void> persistCheckpoint(Checkpoint persistThis)
     {
     	TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(persistThis.getPartitionId(),

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionContext.java
@@ -180,7 +180,7 @@ public class PartitionContext
     	else
     	{
 	    	Checkpoint capturedCheckpoint = new Checkpoint(this.partitionId, this.offset, this.sequenceNumber);
-	    	result = persistCheckpoint(capturedCheckpoint);
+	    	result = checkpoint(capturedCheckpoint);
     	}
     	return result;
     }
@@ -195,7 +195,7 @@ public class PartitionContext
      */
     public CompletableFuture<Void> checkpoint(EventData event)
     {
-    	return persistCheckpoint(new Checkpoint(this.partitionId, event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber()));
+    	return checkpoint(new Checkpoint(this.partitionId, event.getSystemProperties().getOffset(), event.getSystemProperties().getSequenceNumber()));
     }
 
     /**
@@ -208,14 +208,9 @@ public class PartitionContext
      */
     public CompletableFuture<Void> checkpoint(Checkpoint checkpoint)
     {
-        return persistCheckpoint(checkpoint);
-    }
+    	TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(checkpoint.getPartitionId(),
+                "Saving checkpoint: " + checkpoint.getOffset() + "//" + checkpoint.getSequenceNumber()));
 
-    private CompletableFuture<Void> persistCheckpoint(Checkpoint persistThis)
-    {
-    	TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(persistThis.getPartitionId(),
-                "Saving checkpoint: " + persistThis.getOffset() + "//" + persistThis.getSequenceNumber()));
-		
-        return this.hostContext.getCheckpointManager().updateCheckpoint(this.lease, persistThis);
+        return this.hostContext.getCheckpointManager().updateCheckpoint(this.lease, checkpoint);
     }
 }


### PR DESCRIPTION
## Description
In our complex application we're doing manual checkpoint management, that sets checkpoints asynchronously after some time elapsed (e.g. 5 minutes). For this timespan we need to carry the EventData object with us, because it contains the offset and sequence number which is needed for setting the checkpoint. However, during this timespan we don't need anything else from the EventData object, because we retrieved and processed it's payload already. But since we are forced to keep the EventData object, it forces us to keep unneccessary data in memory until the 5 minute batch is processed. In fact it more than _doubles_ our memory requirement!

If you'd accept this pull request, we could create the Checkpoint instances ourselves (using the public constructor and `ParticationContext.getPartitionId()`, `eventData.getSystemProperties().getOffset()` and `eventData.getSystemProperties().getSequenceNumber())`, which has a much smaller footprint.


This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.