### PR TITLE
Relocating AmqpException

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpException.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpException.java
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft. All rights reserved.
  * Licensed under the MIT license. See LICENSE file in the project root for full license information.
  */
-package com.microsoft.azure.eventhubs;
+package com.microsoft.azure.eventhubs.impl;
 
 import org.apache.qpid.proton.amqp.transport.*;
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -20,7 +20,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
-import com.microsoft.azure.eventhubs.AmqpException;
 import com.microsoft.azure.eventhubs.BatchOptions;
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.EventData;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
@@ -68,7 +68,7 @@ public final class ExceptionUtil {
             case BAD_REQUEST:
                 return new IllegalArgumentException(String.format(ClientConstants.AMQP_PUT_TOKEN_FAILED_ERROR, statusCode, statusDescription));
             case NOT_FOUND:
-                return new AmqpException(new ErrorCondition(AmqpErrorCode.NotFound, statusDescription));
+                return new EventHubException(false, new AmqpException(new ErrorCondition(AmqpErrorCode.NotFound, statusDescription)));
             case FORBIDDEN:
                 return new QuotaExceededException(String.format(ClientConstants.AMQP_PUT_TOKEN_FAILED_ERROR, statusCode, statusDescription));
             case UNAUTHORIZED:

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseChannel.java
@@ -9,7 +9,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.HashMap;
 import java.util.UUID;
 
-import com.microsoft.azure.eventhubs.AmqpException;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.amqp.messaging.Target;
@@ -141,7 +140,7 @@ public class RequestResponseChannel implements IOObject {
                     final ErrorCondition error = (this.sendLink.getRemoteCondition() != null && this.sendLink.getRemoteCondition().getCondition() != null)
                             ? this.sendLink.getRemoteCondition()
                             : this.receiveLink.getRemoteCondition();
-                    onOpen.onError(new AmqpException(error));
+                    onOpen.onError(ExceptionUtil.toException(error));
                 }
             }
     }
@@ -205,7 +204,7 @@ public class RequestResponseChannel implements IOObject {
             if (condition == null || condition.getCondition() == null)
                 onLinkCloseComplete(null);
             else
-                onError(new AmqpException(condition));
+                onError(ExceptionUtil.toException(condition));
         }
 
     }
@@ -255,7 +254,7 @@ public class RequestResponseChannel implements IOObject {
                     onLinkCloseComplete(null);
             }
             else {
-                this.onError(new AmqpException(condition));
+                this.onError(ExceptionUtil.toException(condition));
             }
         }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseOpener.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseOpener.java
@@ -2,7 +2,6 @@ package com.microsoft.azure.eventhubs.impl;
 
 import java.util.function.BiConsumer;
 
-import com.microsoft.azure.eventhubs.AmqpException;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.Session;
 
@@ -32,7 +31,7 @@ public class RequestResponseOpener implements Operation<RequestResponseChannel> 
                     @Override
                     public void accept(ErrorCondition error, Exception exception) {
                         if (error != null)
-                            operationCallback.onError(new AmqpException(error));
+                            operationCallback.onError(ExceptionUtil.toException(error));
                         else if (exception != null)
                             operationCallback.onError(exception);
                     }


### PR DESCRIPTION
Ideally, we could remove "public" from AmqpException as well. However, it's used in `com.microsoft.azure.eventhubs.sendrecv`. Thoughts?