### PR TITLE
Scrub volatile fields

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -48,10 +48,11 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
     private final String eventHubName;
     private final Object senderCreateSync;
 
-    private MessagingFactory underlyingFactory;
-    private MessageSender sender;
+    private volatile MessagingFactory underlyingFactory;
+    private volatile MessageSender sender;
+    private volatile Timer timer;
+
     private CompletableFuture<Void> createSender;
-    private Timer timer;
 
     private EventHubClientImpl(final ConnectionStringBuilder connectionString, final Executor executor) throws IOException, IllegalEntityException {
         super(StringUtil.getRandomString(), null, executor);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
@@ -67,15 +67,15 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
     private final Timer timer;
 
     private volatile int nextCreditToFlow;
+    private volatile Receiver receiveLink;
+    private volatile Duration receiveTimeout;
+    private volatile Message lastReceivedMessage;
+    private volatile boolean creatingLink;
+    private volatile CompletableFuture<?> openTimer;
+    private volatile CompletableFuture<?> closeTimer;
 
     private int prefetchCount;
-    private Receiver receiveLink;
-    private Duration receiveTimeout;
-    private Message lastReceivedMessage;
     private Exception lastKnownLinkError;
-    private boolean creatingLink;
-    private CompletableFuture<?> openTimer;
-    private CompletableFuture<?> closeTimer;
 
     private MessageReceiver(final MessagingFactory factory,
                             final String name,

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
@@ -75,14 +75,14 @@ public final class MessageSender extends ClientEntity implements AmqpSender, Err
 
     private volatile int maxMessageSize;
     private volatile Sender sendLink;
+    private volatile CompletableFuture<MessageSender> linkFirstOpen;
+    private volatile TimeoutTracker openLinkTracker;
+    private volatile boolean creatingLink;
+    private volatile CompletableFuture<?> closeTimer;
+    private volatile CompletableFuture<?> openTimer;
 
-    private CompletableFuture<MessageSender> linkFirstOpen;
-    private TimeoutTracker openLinkTracker;
     private Exception lastKnownLinkError;
     private Instant lastKnownErrorReportedAt;
-    private boolean creatingLink;
-    private CompletableFuture<?> closeTimer;
-    private CompletableFuture<?> openTimer;
 
     public static CompletableFuture<MessageSender> create(
             final MessagingFactory factory,

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
@@ -16,7 +16,7 @@ final class PartitionSenderImpl extends ClientEntity implements PartitionSender 
     private final String eventHubName;
     private final MessagingFactory factory;
 
-    private MessageSender internalSender;
+    private volatile MessageSender internalSender;
 
     private PartitionSenderImpl(final MessagingFactory factory, final String eventHubName, final String partitionId, final Executor executor) {
         super(null, null, executor);


### PR DESCRIPTION
Mark the fields which could be running on multiple threads as a result of the recent threading model change (#215, #269) to 'volatile'.