### PR TITLE
fix CIT failures due to AmqpException change

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
@@ -68,7 +68,7 @@ public final class ExceptionUtil {
             case BAD_REQUEST:
                 return new IllegalArgumentException(String.format(ClientConstants.AMQP_PUT_TOKEN_FAILED_ERROR, statusCode, statusDescription));
             case NOT_FOUND:
-                return new EventHubException(false, new AmqpException(new ErrorCondition(AmqpErrorCode.NotFound, statusDescription)));
+                return new IllegalEntityException(statusDescription);
             case FORBIDDEN:
                 return new QuotaExceededException(String.format(ClientConstants.AMQP_PUT_TOKEN_FAILED_ERROR, statusCode, statusDescription));
             case UNAUTHORIZED:

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -250,9 +250,7 @@ public class RequestResponseTest  extends ApiTestBase {
     		if (e.getCause() == null) {
     			Assert.fail("Got ExecutionException but no inner exception");
     		}
-    		else if (e.getCause() instanceof AmqpException) {
-    			// TODO we should really be returning a MessagingEntityNotFound exception
-    			// but that can be an enhancement for later, right now it's an AmqpException
+    		else if (e.getCause() instanceof IllegalEntityException) {
     			Assert.assertTrue(e.getCause().getMessage().contains("could not be found"));
     		}
     		else {
@@ -271,9 +269,7 @@ public class RequestResponseTest  extends ApiTestBase {
     		if (e.getCause() == null) {
     			Assert.fail("Got ExecutionException but no inner exception");
     		}
-    		else if (e.getCause() instanceof AmqpException) {
-    			// TODO we should really be returning a MessagingEntityNotFound exception
-    			// but that can be an enhancement for later, right now it's an AmqpException
+    		else if (e.getCause() instanceof IllegalEntityException) {
     			Assert.assertTrue(e.getCause().getMessage().contains("could not be found"));
     		}
     		else {


### PR DESCRIPTION
cleanup exception contract for `EventHub Not found` case - for mgmt API's to return specific exception - `IllegalEntityException` instead of `EventHubsException`

