### PR TITLE
Improve EPH lease handling for large partition counts

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/AzureStorageCheckpointLeaseManager.java
@@ -18,15 +18,17 @@ import java.nio.file.Paths;
 import java.security.InvalidKeyException;
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 
 class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseManager {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(AzureStorageCheckpointLeaseManager.class);
+    private static final String METADATA_OWNER_NAME = "OWNINGHOST";
+    
     private final String storageConnectionString;
     private final String storageBlobPrefix;
     private final BlobRequestOptions leaseOperationOptions = new BlobRequestOptions();
@@ -40,12 +42,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     private ArrayList<String> partitionIds = null;
     private Gson gson;
 
-    ;
     private Hashtable<String, Checkpoint> latestCheckpoint = new Hashtable<String, Checkpoint>();
-
-    AzureStorageCheckpointLeaseManager(String storageConnectionString) {
-        this(storageConnectionString, null);
-    }
 
     AzureStorageCheckpointLeaseManager(String storageConnectionString, String storageContainerName) {
         this(storageConnectionString, storageContainerName, "");
@@ -72,22 +69,6 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     // hence we don't want it in the constructor.
     void initialize(HostContext hostContext) throws InvalidKeyException, URISyntaxException, StorageException {
         this.hostContext = hostContext;
-        if (this.storageContainerName == null) {
-            this.storageContainerName = this.hostContext.getEventHubPath();
-        }
-
-        // Validate that the event hub name is also a legal storage container name.
-        // Regex pattern is copied from .NET version. The syntax for Java regexes seems to be the same.
-        // Error message is also copied from .NET version.
-        Pattern p = Pattern.compile("^(?-i)(?:[a-z0-9]|(?<=[0-9a-z])-(?=[0-9a-z])){3,63}$");
-        Matcher m = p.matcher(this.storageContainerName);
-        if (!m.find()) {
-            throw new IllegalArgumentException("EventHub names must conform to the following rules to be able to use it with EventProcessorHost: " +
-                    "Must start with a letter or number, and can contain only letters, numbers, and the dash (-) character. " +
-                    "Every dash (-) character must be immediately preceded and followed by a letter or number; consecutive dashes are not permitted in container names. " +
-                    "All letters in a container name must be lowercase. " +
-                    "Must be from 3 to 63 characters long.");
-        }
 
         this.storageClient = CloudStorageAccount.parse(this.storageConnectionString).createCloudBlobClient();
 
@@ -127,13 +108,9 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
 
     @Override
     public CompletableFuture<Void> createCheckpointStoreIfNotExists() {
-        return createLeaseStoreIfNotExistsInternal(this.checkpointOperationOptions, EventProcessorHostActionStrings.CREATING_CHECKPOINT_STORE)
-                .whenCompleteAsync((result, e) ->
-                {
-                    if (e != null) {
-                        TRACE_LOGGER.error(this.hostContext.withHost("Failure while creating checkpoint store"), LoggingUtils.unwrapException(e, null));
-                    }
-                }, this.hostContext.getExecutor());
+    	// Because we control the caller, we know that this method will only be called after createLeaseStoreIfNotExists.
+    	// In this implementation, it's the same store, so the store will always exist if execution reaches here.
+    	return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -165,27 +142,10 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     }
 
     @Override
-    public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId) {
-        return CompletableFuture.supplyAsync(() ->
-        {
-            // Normally the lease will already be created, checkpoint store is initialized after lease store.
-            AzureBlobLease lease = null;
-            try {
-                lease = createLeaseIfNotExistsInternal(partitionId, this.checkpointOperationOptions);
-            } catch (URISyntaxException | IOException | StorageException e) {
-                TRACE_LOGGER.error(this.hostContext.withHostAndPartition(partitionId,
-                        "CreateCheckpointIfNotExist exception - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " + this.hostContext.getConsumerGroupName() +
-                                "storageBlobPrefix: " + this.storageBlobPrefix), e);
-                throw LoggingUtils.wrapException(e, EventProcessorHostActionStrings.CREATING_CHECKPOINT);
-            }
-
-            Checkpoint checkpoint = null;
-            if (lease.getOffset() != null) {
-                checkpoint = new Checkpoint(partitionId, lease.getOffset(), lease.getSequenceNumber());
-            }
-
-            return checkpoint;
-        }, this.hostContext.getExecutor());
+    public CompletableFuture<Void> createAllCheckpointsIfNotExists(List<String> partitionIds) {
+    	// Because we control the caller, we know that this method will only be called after createAllLeasesIfNotExists.
+    	// In this implementation checkpoints are in the same blobs as leases, so the blobs will already exist if execution reaches here.
+    	return CompletableFuture.completedFuture(null);
     }
 
     @Override
@@ -311,7 +271,8 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
         }, this.hostContext.getExecutor());
     }
 
-    private CompletableFuture<Lease> getLease(String partitionId) {
+    @Override
+    public CompletableFuture<Lease> getLease(String partitionId) {
         return CompletableFuture.supplyAsync(() ->
         {
             Lease result = null;
@@ -371,45 +332,83 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
     }
 
     private CompletableFuture<Void> cachePartitionIds() {
-        CompletableFuture<Void> result = null;
-
-        if (this.partitionIds != null) {
-            result = CompletableFuture.completedFuture(null);
-        } else {
-            result = CompletableFuture.runAsync(() ->
-            {
-                try {
-                    Iterable<ListBlobItem> blobList = this.consumerGroupDirectory.listBlobs("", true, null, this.leaseOperationOptions, null);
-                    this.partitionIds = new ArrayList<String>();
-                    blobList.forEach((lbi) ->
-                    {
-                        Path p = Paths.get(lbi.getUri().getPath());
-                        this.partitionIds.add(p.getFileName().toString());
-                    });
-                } catch (URISyntaxException | StorageException e) {
-                    throw new CompletionException(e);
-                }
-            }, this.hostContext.getExecutor());
-
-        }
+        CompletableFuture<Void> result = CompletableFuture.completedFuture(null);
         return result;
+    }
+    
+    @Override
+    public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo() {
+    	return CompletableFuture.supplyAsync(() -> {
+	    	ArrayList<LeaseStateInfo> infos = new ArrayList<LeaseStateInfo>();
+	    	
+	    	try {
+		    	EnumSet<BlobListingDetails> details = EnumSet.of(BlobListingDetails.METADATA);
+				Iterable<ListBlobItem> leaseBlobs = this.consumerGroupDirectory.listBlobs("", true, details, this.leaseOperationOptions, null);
+				leaseBlobs.forEach((lbi) -> {
+					CloudBlob blob = (CloudBlob)lbi;
+					BlobProperties bp = blob.getProperties();
+					HashMap<String, String> metadata = blob.getMetadata();
+					Path p = Paths.get(lbi.getUri().getPath());
+					infos.add(new LeaseStateInfo(p.getFileName().toString(), metadata.get(AzureStorageCheckpointLeaseManager.METADATA_OWNER_NAME),
+							(bp.getLeaseState() == LeaseState.LEASED)));
+				});
+			} catch (URISyntaxException | StorageException e) {
+                TRACE_LOGGER.warn(this.hostContext.withHost("Failure while getting lease state details"), e);
+                throw LoggingUtils.wrapException(e, EventProcessorHostActionStrings.GETTING_LEASE);
+			}
+	    	
+	    	return infos;
+    	}, this.hostContext.getExecutor());
     }
 
     @Override
-    public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId) {
-        return CompletableFuture.supplyAsync(() ->
-        {
-            Lease returnLease = null;
-            try {
-                returnLease = createLeaseIfNotExistsInternal(partitionId, this.leaseOperationOptions);
-            } catch (URISyntaxException | IOException | StorageException e) {
-                TRACE_LOGGER.error(this.hostContext.withHostAndPartition(partitionId,
-                        "CreateLeaseIfNotExist exception - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " + this.hostContext.getConsumerGroupName() +
-                                " storageBlobPrefix: " + this.storageBlobPrefix), e);
-                throw LoggingUtils.wrapException(e, EventProcessorHostActionStrings.CREATING_LEASE);
-            }
-            return returnLease;
-        }, this.hostContext.getExecutor());
+    public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds) {
+    	this.partitionIds = new ArrayList<String>(partitionIds);
+    	
+    	return CompletableFuture.supplyAsync(() -> {
+		    	// Optimization: list the blobs currently existing in the directory. If there are the
+		    	// expected number of blobs, then we can skip doing the creates.
+    			int blobCount = 0;
+		    	try {
+					Iterable<ListBlobItem> leaseBlobs = this.consumerGroupDirectory.listBlobs("", true, null, this.leaseOperationOptions, null);
+					Iterator<ListBlobItem> blobIterator = leaseBlobs.iterator();
+					while (blobIterator.hasNext()) {
+						blobCount++;
+						blobIterator.next();
+					}
+				} catch (URISyntaxException | StorageException e) {
+					TRACE_LOGGER.error(this.hostContext.withHost("Exception checking lease existence - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " +
+							this.hostContext.getConsumerGroupName() + " storageBlobPrefix: " + this.storageBlobPrefix), e);
+					throw LoggingUtils.wrapException(e, EventProcessorHostActionStrings.CREATING_LEASES);
+				}
+				return (blobCount == partitionIds.size());
+	    	}, this.hostContext.getExecutor())
+    	.thenComposeAsync((exists) -> {
+    			CompletableFuture<Void> createAllFuture = CompletableFuture.completedFuture(null);
+    			if (!exists) {
+			    	ArrayList<CompletableFuture<Lease>> createFutures = new ArrayList<CompletableFuture<Lease>>();
+			    	
+			    	for (String id : partitionIds) {
+			            CompletableFuture<Lease> oneCreate = CompletableFuture.supplyAsync(() -> {
+				                Lease returnLease = null;
+				                try {
+				                    returnLease = createLeaseIfNotExistsInternal(id, this.leaseOperationOptions);
+				                } catch (URISyntaxException | IOException | StorageException e) {
+				                    TRACE_LOGGER.error(this.hostContext.withHostAndPartition(id,
+				                            "Exception creating lease - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " + this.hostContext.getConsumerGroupName() +
+				                                    " storageBlobPrefix: " + this.storageBlobPrefix), e);
+				                    throw LoggingUtils.wrapException(e, EventProcessorHostActionStrings.CREATING_LEASES);
+				                }
+				                return returnLease;
+				            }, this.hostContext.getExecutor());
+			            createFutures.add(oneCreate);
+			    	}
+			
+			    	CompletableFuture<?> dummy[] = new CompletableFuture<?>[createFutures.size()];
+			    	createAllFuture = CompletableFuture.allOf(createFutures.toArray(dummy));
+    			}
+    			return createAllFuture;
+    		}, this.hostContext.getExecutor());
     }
 
     private AzureBlobLease createLeaseIfNotExistsInternal(String partitionId, BlobRequestOptions options) throws URISyntaxException, IOException, StorageException {
@@ -418,6 +417,7 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
             CloudBlockBlob leaseBlob = this.consumerGroupDirectory.getBlockBlobReference(partitionId); // getBlockBlobReference does not take options
             returnLease = new AzureBlobLease(partitionId, leaseBlob, this.leaseOperationOptions);
             uploadLease(returnLease, leaseBlob, AccessCondition.generateIfNoneMatchCondition("*"), UploadActivity.Create, options);
+            // Do not set metadata on creation. No metadata/no owner value indicates that the lease is unowned.
             TRACE_LOGGER.info(this.hostContext.withHostAndPartition(partitionId,
                     "CreateLeaseIfNotExist OK - leaseContainerName: " + this.storageContainerName + " consumerGroupName: " + this.hostContext.getConsumerGroupName() +
                             " storageBlobPrefix: " + this.storageBlobPrefix));
@@ -649,6 +649,29 @@ class AzureStorageCheckpointLeaseManager implements ICheckpointManager, ILeaseMa
         // avoids a spurious trace in that case.
         TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(lease,
                 "Raw JSON uploading for " + activity + ": " + jsonLease));
+        
+        if ((activity == UploadActivity.Acquire) || (activity == UploadActivity.Release)) {
+        	blob.downloadAttributes();
+        	HashMap<String, String> metadata = blob.getMetadata();
+        	switch (activity) {
+        	case Acquire:
+            	// Add owner in metadata
+            	metadata.put(AzureStorageCheckpointLeaseManager.METADATA_OWNER_NAME, lease.getOwner());
+        		break;
+        		
+        	case Release:
+            	// Remove owner in metadata
+            	metadata.remove(AzureStorageCheckpointLeaseManager.METADATA_OWNER_NAME);
+        		break;
+        		
+			default:
+				// Should never get here, but passing the metadata through unchanged is harmless.
+				break;
+        	}
+        	blob.setMetadata(metadata);
+        	blob.uploadMetadata(condition, options, null);
+        }
+        // else don't touch metadata
     }
 
     private boolean wasLeaseLost(StorageException se, String partitionId) {

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHost.java
@@ -25,7 +25,7 @@ public final class EventProcessorHost {
     // weOwnExecutor exists to support user-supplied thread pools.
     private final boolean weOwnExecutor;
     private final ScheduledExecutorService executorService;
-    private final int executorServicePoolSize = 8;
+    private final int executorServicePoolSize = 16;
     private final HostContext hostContext;
     private boolean initializeLeaseManager = false;
     private boolean unregistered = false;
@@ -162,7 +162,6 @@ public final class EventProcessorHost {
         this(hostName, eventHubPath, consumerGroupName, eventHubConnectionString, combinedManager, combinedManager, executorService, null);
     }
 
-
     /**
      * Create a new host to process events from an Event Hub.
      * <p>
@@ -215,7 +214,6 @@ public final class EventProcessorHost {
         }
 
         // eventHubPath is allowed to be null or empty if it is provided in the connection string. That will be checked later.
-
         if ((consumerGroupName == null) || consumerGroupName.isEmpty()) {
             throw new IllegalArgumentException("consumerGroupName argument must not be null or empty");
         }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHostActionStrings.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorHostActionStrings.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
 package com.microsoft.azure.eventprocessorhost;
 
 /***
@@ -10,11 +15,11 @@ public final class EventProcessorHostActionStrings {
     public final static String CHECKING_LEASES = "Checking Leases";
     public final static String CHECKING_LEASE_STORE = "Checking Lease Store Existence";
     public final static String CLOSING_EVENT_PROCESSOR = "Closing Event Processor";
-    public final static String CREATING_CHECKPOINT = "Creating Checkpoint";
+    public final static String CREATING_CHECKPOINTS = "Creating Checkpoint Holders";
     public final static String CREATING_CHECKPOINT_STORE = "Creating Checkpoint Store";
     public final static String CREATING_EVENT_HUB_CLIENT = "Creating Event Hub Client";
     public final static String CREATING_EVENT_PROCESSOR = "Creating Event Processor";
-    public final static String CREATING_LEASE = "Creating Lease";
+    public final static String CREATING_LEASES = "Creating Leases";
     public final static String CREATING_LEASE_STORE = "Creating Lease Store";
     public final static String DELETING_LEASE = "Deleting Lease";
     public final static String GETTING_CHECKPOINT = "Getting Checkpoint Details";

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -72,22 +72,6 @@ public interface ICheckpointManager {
     public CompletableFuture<Void> createAllCheckpointsIfNotExists(List<String> partitionIds);
 
     /***
-     * If a checkpoint HOLDER for the given partition exists, return the checkpoint if there is one,
-     * or null if it has not been initialized. If the HOLDER doesn't exist, create it and return null.
-     *
-     * The semantics of this are complicated because it is possible to use the same store for both
-     * leases and checkpoints (the Azure Storage implementation does so) and it is required to
-     * have a lease for every partition but it is not required to have a checkpoint for a partition.
-     * It is a valid scenario to never use checkpoints at all, so it is important for the store to
-     * distinguish between creating the structure(s) that will hold a checkpoint and actually creating
-     * a checkpoint (storing an offset/sequence number pair in the structure).
-     *
-     * @param partitionId  Id of partition to create the checkpoint HOLDER for.
-     * @return CompletableFuture {@literal ->} the checkpoint for the given partition, if one exists, or null. Completes exceptionally on error.
-     */
-    public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId);
-
-    /***
      * Update the checkpoint in the store with the offset/sequenceNumber in the provided checkpoint.
      *
      * The lease argument is necessary to make the Azure Storage implementation work correctly: the

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -5,6 +5,7 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 /***
@@ -55,8 +56,8 @@ public interface ICheckpointManager {
     public CompletableFuture<Checkpoint> getCheckpoint(String partitionId);
 
     /***
-     * If a checkpoint HOLDER for the given partition exists, return the checkpoint if there is one,
-     * or null if it has not been initialized. If the HOLDER doesn't exist, create it and return null.
+	 * Creates the checkpoint HOLDERs for the given partitions. Does nothing for any checkpoint HOLDERs
+	 * that already exist.
      *
      * The semantics of this are complicated because it is possible to use the same store for both
      * leases and checkpoints (the Azure Storage implementation does so) and it is required to
@@ -65,10 +66,10 @@ public interface ICheckpointManager {
      * distinguish between creating the structure(s) that will hold a checkpoint and actually creating
      * a checkpoint (storing an offset/sequence number pair in the structure).
      *
-     * @param partitionId  Id of partition to create the checkpoint HOLDER for.
-     * @return CompletableFuture {@literal ->} the checkpoint for the given partition, if one exists, or null. Completes exceptionally on error.
+     * @param partitionId  Id of partitions to create checkpoint HOLDERs for.
+     * @return CompletableFuture {@literal ->} null on success, completes exceptionally on error.
      */
-    public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId);
+    public CompletableFuture<Void> createAllCheckpointsIfNotExists(List<String> partitionIds);
 
     /***
      * Update the checkpoint in the store with the offset/sequenceNumber in the provided checkpoint.

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ICheckpointManager.java
@@ -66,10 +66,26 @@ public interface ICheckpointManager {
      * distinguish between creating the structure(s) that will hold a checkpoint and actually creating
      * a checkpoint (storing an offset/sequence number pair in the structure).
      *
-     * @param partitionId  Id of partitions to create checkpoint HOLDERs for.
+     * @param partitionIds  List of partitions to create checkpoint HOLDERs for.
      * @return CompletableFuture {@literal ->} null on success, completes exceptionally on error.
      */
     public CompletableFuture<Void> createAllCheckpointsIfNotExists(List<String> partitionIds);
+
+    /***
+     * If a checkpoint HOLDER for the given partition exists, return the checkpoint if there is one,
+     * or null if it has not been initialized. If the HOLDER doesn't exist, create it and return null.
+     *
+     * The semantics of this are complicated because it is possible to use the same store for both
+     * leases and checkpoints (the Azure Storage implementation does so) and it is required to
+     * have a lease for every partition but it is not required to have a checkpoint for a partition.
+     * It is a valid scenario to never use checkpoints at all, so it is important for the store to
+     * distinguish between creating the structure(s) that will hold a checkpoint and actually creating
+     * a checkpoint (storing an offset/sequence number pair in the structure).
+     *
+     * @param partitionId  Id of partition to create the checkpoint HOLDER for.
+     * @return CompletableFuture {@literal ->} the checkpoint for the given partition, if one exists, or null. Completes exceptionally on error.
+     */
+    public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId);
 
     /***
      * Update the checkpoint in the store with the offset/sequenceNumber in the provided checkpoint.

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
@@ -84,6 +84,15 @@ public interface ILeaseManager {
     public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds);
 
     /**
+     * Create in the store the lease for the given partition, if it does not exist. Do nothing if it exists
+     * in the store already.
+     *
+     * @param partitionId id of partition to create lease info for
+     * @return CompletableFuture {@literal ->} the existing or newly-created lease info for the partition, completes exceptionally on error
+     */
+    public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId);
+
+    /**
      * Delete the lease info for a partition from the store. If there is no stored lease for the given partition,
      * that is treated as success.
      *

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
@@ -22,16 +22,6 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface ILeaseManager {
     /**
-     * The lease renew interval is used by PartitionManager to determine how often it should
-     * scan leases and renew them. In order to redistribute leases in a timely fashion after a host
-     * ceases operating, we recommend a relatively short interval, such as ten seconds. Obviously it
-     * should be less than half of the lease length, to prevent accidental expiration.
-     *
-     * @return The sleep interval between scans, specified in milliseconds.
-     */
-    public int getLeaseRenewIntervalInMilliseconds();
-
-    /**
      * The lease duration is mostly internal to the lease manager implementation but may be needed
      * by other parts of the event processor host.
      *
@@ -64,15 +54,21 @@ public interface ILeaseManager {
     public CompletableFuture<Void> deleteLeaseStore();
 
     /**
-     * Returns the lease info for all partitions.
+     * Returns the lease info for the given partition..
      *
-     * @return CompletableFuture {@literal ->} list of Leases, completes exceptionally on error.
+     * @param partitionId  Get the lease info for this partition.
+     * @return CompletableFuture {@literal ->} Lease, completes exceptionally on error.
      */
-    public CompletableFuture<List<Lease>> getAllLeases();
-    
+    public CompletableFuture<Lease> getLease(String partitionId);
+
+    /**
+     * Returns LeaseStateInfo for all leases, which includes name of owning host and whether lease
+     * is expired.
+     * 
+     * @return CompletableFuture {@literal ->} list of LeaseStateInfo, completes exceptionally on error.
+     */
     public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo();
     
-    public CompletableFuture<Lease> getLease(String partitionId);
 
     /**
      * Create in the store a lease for each of the given partitions, if it does not exist. Do nothing for any
@@ -82,15 +78,6 @@ public interface ILeaseManager {
      * @return CompletableFuture {@literal ->} null on success, completes exceptionally on error
      */
     public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds);
-
-    /**
-     * Create in the store the lease for the given partition, if it does not exist. Do nothing if it exists
-     * in the store already.
-     *
-     * @param partitionId id of partition to create lease info for
-     * @return CompletableFuture {@literal ->} the existing or newly-created lease info for the partition, completes exceptionally on error
-     */
-    public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId);
 
     /**
      * Delete the lease info for a partition from the store. If there is no stored lease for the given partition,

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/ILeaseManager.java
@@ -69,15 +69,19 @@ public interface ILeaseManager {
      * @return CompletableFuture {@literal ->} list of Leases, completes exceptionally on error.
      */
     public CompletableFuture<List<Lease>> getAllLeases();
+    
+    public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo();
+    
+    public CompletableFuture<Lease> getLease(String partitionId);
 
     /**
-     * Create in the store the lease for the given partition, if it does not exist. Do nothing if it exists
-     * in the store already.
+     * Create in the store a lease for each of the given partitions, if it does not exist. Do nothing for any
+     * lease which exists in the store already.
      *
-     * @param partitionId id of partition to create lease info for
-     * @return CompletableFuture {@literal ->} the existing or newly-created lease info for the partition, completes exceptionally on error
+     * @param partitionIds ids of partitions to create lease info for
+     * @return CompletableFuture {@literal ->} null on success, completes exceptionally on error
      */
-    public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId);
+    public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds);
 
     /**
      * Delete the lease info for a partition from the store. If there is no stored lease for the given partition,

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryCheckpointManager.java
@@ -108,34 +108,6 @@ public class InMemoryCheckpointManager implements ICheckpointManager {
     }
 
     @Override
-    public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId) {
-        Checkpoint checkpointInStore = InMemoryCheckpointStore.singleton.getCheckpoint(partitionId);
-        Checkpoint returnCheckpoint = null;
-        if (checkpointInStore != null) {
-            TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(partitionId,
-                    "createCheckpointIfNotExists() found existing checkpoint, OK"));
-            if (checkpointInStore.getSequenceNumber() != -1) {
-                returnCheckpoint = new Checkpoint(checkpointInStore);
-            } else {
-                // The checkpoint is uninitialized so return null to match the behavior of AzureStorageCheckpointLeaseMananger.
-                returnCheckpoint = null;
-            }
-        } else {
-            TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(partitionId,
-                    "createCheckpointIfNotExists() creating new checkpoint"));
-            Checkpoint newStoreCheckpoint = new Checkpoint(partitionId);
-            newStoreCheckpoint.setOffset(null);
-            newStoreCheckpoint.setSequenceNumber(-1);
-            InMemoryCheckpointStore.singleton.setOrReplaceCheckpoint(newStoreCheckpoint);
-            // This API actually creates the holder, not the checkpoint itself. In this implementation, we do create a Checkpoint object
-            // and put it in the store, but the values are set to indicate that it is not initialized. Meanwhile, return null to match the
-            // behavior of AzureStorageCheckpointLeaseMananger.
-            returnCheckpoint = null;
-        }
-        return CompletableFuture.completedFuture(returnCheckpoint);
-    }
-
-    @Override
     public CompletableFuture<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint) {
         TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(checkpoint.getPartitionId(),
                 "updateCheckpoint() " + checkpoint.getOffset() + "//" + checkpoint.getSequenceNumber()));

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/InMemoryLeaseManager.java
@@ -179,6 +179,11 @@ public class InMemoryLeaseManager implements ILeaseManager {
     }
 
     @Override
+    public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId) {
+        return null;
+    }
+
+    @Override
     public CompletableFuture<Void> deleteLease(Lease lease) {
         TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(lease, "deleteLease()"));
         InMemoryLeaseStore.singleton.removeLease((InMemoryLease) lease);

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/Lease.java
@@ -5,8 +5,6 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import java.util.concurrent.CompletableFuture;
-
 /**
  * Lease class is public so that advanced users can implement an ILeaseManager.
  * Unless you are implementing ILeaseManager you should not have to deal with objects
@@ -153,17 +151,6 @@ public class Lease {
      */
     public void setToken(String token) {
         this.token = token;
-    }
-
-    /**
-     * A class derived from Lease should override this function to inspect the lease and return whether it has expired.
-     * Uses CompletableFuture because determining whether a lease is expired may involve I/O.
-     *
-     * @return CompletableFuture {@literal ->} true if the lease is expired, false if it is still valid, completes exceptionally on error.
-     */
-    public CompletableFuture<Boolean> isExpired() {
-        // this function is meaningless in the base class
-        return CompletableFuture.completedFuture(false);
     }
 
     String getStateDebug() {

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LeaseStateInfo.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/LeaseStateInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.eventprocessorhost;
+
+public class LeaseStateInfo implements Comparable<LeaseStateInfo> {
+	private final String partitionId;
+	private final String owner;
+	private final boolean isOwned;
+	
+	private Lease lease = null;
+
+	public LeaseStateInfo(String partitionId, String owner, boolean isOwned) {
+		this.partitionId = partitionId;
+		this.owner = owner;
+		this.isOwned = isOwned;
+	}
+	
+	public String getPartitionId() {
+		return this.partitionId;
+	}
+	
+	public String getOwner() {
+		return this.owner;
+	}
+	
+	public boolean isOwned() {
+		return this.isOwned;
+	}
+	
+	public void setLease(Lease lease) {
+		this.lease = lease;
+	}
+	
+	public Lease getLease() {
+		return this.lease;
+	}
+
+	// Compares by partition id
+	@Override
+	public int compareTo(LeaseStateInfo other) {
+		return this.partitionId.compareTo(other.getPartitionId());
+	}
+}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -14,7 +14,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.concurrent.*;
 
 class PartitionManager {
@@ -149,14 +148,10 @@ class PartitionManager {
                 // Stage 3: schedule scan, which will find partitions and start pumps, if previous stages succeeded
                 .thenRunAsync(() ->
                 {
-                    // Schedule the first scan.
+                    // Schedule the first scan immediately.
                     synchronized (this.scanFutureSynchronizer) {
-                        // Wait a random amount of time before doing the first scan.
-                        // The random wait is to minimize contention while establishing beachhead leases.
-                        Random pickWait = new Random();
-                        int seconds = 0;
-                        TRACE_LOGGER.info(this.hostContext.withHost("Scheduling lease scanner in " + seconds)); // FOO
-                        this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(true), seconds, TimeUnit.SECONDS);
+                        TRACE_LOGGER.info(this.hostContext.withHost("Scheduling lease scanner first pass")); // FOO
+                        this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(true), 0, TimeUnit.SECONDS);
                     }
 
                     onInitializeCompleteTestHook();

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -150,7 +150,7 @@ class PartitionManager {
                 {
                     // Schedule the first scan immediately.
                     synchronized (this.scanFutureSynchronizer) {
-                        TRACE_LOGGER.info(this.hostContext.withHost("Scheduling lease scanner first pass")); // FOO
+                        TRACE_LOGGER.debug(this.hostContext.withHost("Scheduling lease scanner first pass"));
                         this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(true), 0, TimeUnit.SECONDS);
                     }
 
@@ -270,8 +270,8 @@ class PartitionManager {
     // Return Void so it can be called from a lambda.
     // throwOnFailure is true
     private Void scan(boolean isFirst) {
-        TRACE_LOGGER.info(this.hostContext.withHost("Starting lease scan")); // FOO
-        long start = System.currentTimeMillis(); // FOO
+        TRACE_LOGGER.debug(this.hostContext.withHost("Starting lease scan"));
+        long start = System.currentTimeMillis();
 
         // DO NOT check whether this.scanFuture is cancelled. The first execution of this method is scheduled
         // with 0 delay and can occur before this.scanFuture is set to the result of the schedule() call.
@@ -290,8 +290,8 @@ class PartitionManager {
                                 seconds = this.hostContext.getPartitionManagerOptions().getStartupScanDelayInSeconds();
                             }
                             this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(false), seconds, TimeUnit.SECONDS);
-                            TRACE_LOGGER.info(this.hostContext.withHost("Scanning took " + (System.currentTimeMillis() - start))); // FOO
-                            TRACE_LOGGER.info(this.hostContext.withHost("Scheduling lease scanner in " + seconds)); // FOO
+                            TRACE_LOGGER.debug(this.hostContext.withHost("Scanning took " + (System.currentTimeMillis() - start)));
+                            TRACE_LOGGER.debug(this.hostContext.withHost("Scheduling lease scanner in " + seconds));
                         }
                     }
                 }, this.hostContext.getExecutor());

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -13,6 +13,9 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.TimeoutException;
@@ -25,6 +28,7 @@ class PartitionManager {
     protected Pump pump = null;
     protected volatile String partitionIds[] = null;
     private ScheduledFuture<?> scanFuture = null;
+    private final int waitStaggerMax = 60;
 
     PartitionManager(HostContext hostContext) {
         this.hostContext = hostContext;
@@ -150,7 +154,7 @@ class PartitionManager {
                 {
                     // Schedule the first scan right away.
                     synchronized (this.scanFutureSynchronizer) {
-                        this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(), 0, TimeUnit.SECONDS);
+                        this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(true), 0, TimeUnit.SECONDS);
                     }
 
                     onInitializeCompleteTestHook();
@@ -279,204 +283,36 @@ class PartitionManager {
 
     // Return Void so it can be called from a lambda.
     // throwOnFailure is true
-    private Void scan() {
+    private Void scan(boolean isFirst) {
         TRACE_LOGGER.debug(this.hostContext.withHost("Starting lease scan"));
 
         // DO NOT check whether this.scanFuture is cancelled. The first execution of this method is scheduled
         // with 0 delay and can occur before this.scanFuture is set to the result of the schedule() call.
 
-        // These are final so they can be used in the lambdas below.
-        final AtomicInteger ourLeasesCount = new AtomicInteger();
-        final ConcurrentHashMap<String, Lease> leasesOwnedByOthers = new ConcurrentHashMap<String, Lease>();
-        final BoolWrapper resultsAreComplete = new BoolWrapper(true);
-
-        // Stage A: get the list of all leases
-        CompletableFuture<Lease> leaseToStealFuture = this.hostContext.getLeaseManager().getAllLeases()
-                // Stage B: check the state of each lease in parallel, acquiring those which are expired
-                .thenApplyAsync((leaseList) ->
-                {
-                    ArrayList<CompletableFuture<Lease>> transformedLeases = new ArrayList<CompletableFuture<Lease>>();
-                    for (Lease l : leaseList) {
-                        final Lease workingLease = l;
-
-                        if (workingLease != null) {
-                            // Stage B.0: is the lease expired?
-                            CompletableFuture<Lease> oneResult = workingLease.isExpired()
-                                    // Stage B.1: if it is expired, attempt to acquire it.
-                                    .thenComposeAsync((expired) ->
-                                    {
-                                        return expired ? this.hostContext.getLeaseManager().acquireLease(workingLease) : CompletableFuture.completedFuture(false);
-                                    }, this.hostContext.getExecutor())
-                                    // Stage B.2: if it was acquired, start a pump and do the counting.
-                                    .thenApplyAsync((acquired) ->
-                                    {
-                                        if (acquired) {
-                                            this.pump.addPump(workingLease);
-                                        }
-                                        if (workingLease.isOwnedBy(this.hostContext.getHostName())) {
-                                            ourLeasesCount.getAndIncrement(); // count leases owned by this host
-                                        } else {
-                                            leasesOwnedByOthers.put(workingLease.getPartitionId(), workingLease); // save leases owned by other hosts
-                                        }
-                                        return workingLease;
-                                    }, this.hostContext.getExecutor())
-                                    // Stage B.3: ALWAYS RUN REGARDLESS OF EXCEPTIONS -- log/notify if exception occurred
-                                    .whenCompleteAsync((lease, e) ->
-                                    {
-                                        if (e != null) {
-                                            resultsAreComplete.value = false;
-                                            Exception notifyWith = (Exception) LoggingUtils.unwrapException(e, null);
-                                            TRACE_LOGGER.warn(this.hostContext.withHost("Failure getting/acquiring lease, skipping"), notifyWith);
-                                            this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
-                                                    EventProcessorHostActionStrings.CHECKING_LEASES, ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
-                                        }
-                                    }, this.hostContext.getExecutor());
-
-                            transformedLeases.add(oneResult);
-                        } else {
-                            TRACE_LOGGER.warn(this.hostContext.withHost("null lease during scan"));
-                        }
-                    }
-                    return transformedLeases;
-                }, this.hostContext.getExecutor())
-                // Stage C: get a future that waits for all the results
-                .thenComposeAsync((transformedLeases) ->
-                {
-                    CompletableFuture<Void> result = null;
-                    if (transformedLeases.size() > 0) {
-                        CompletableFuture<?>[] dummy = new CompletableFuture<?>[transformedLeases.size()];
-                        result = CompletableFuture.allOf(transformedLeases.toArray(dummy));
-                    } else {
-                        TRACE_LOGGER.warn(this.hostContext.withHost("all leases were null during scan"));
-                        result = CompletableFuture.completedFuture(null);
-                    }
-                    return result;
-                }, this.hostContext.getExecutor())
-                // Stage D: consume the counting done by the per-lease stage to decide whether and what lease to steal
-                .thenApplyAsync((empty) ->
-                {
-                    TRACE_LOGGER.debug(this.hostContext.withHost("Lease scan steal check"));
-
-                    // Grab more leases if available and needed for load balancing, but only if all leases were checked OK.
-                    // Don't try to steal if numbers are in doubt due to errors in the previous stage.
-                    Lease stealThisLease = null;
-                    if ((leasesOwnedByOthers.size() > 0) && resultsAreComplete.value) {
-                        stealThisLease = whichLeaseToSteal(leasesOwnedByOthers.values(), ourLeasesCount.get());
-                    }
-                    return stealThisLease;
-                }, this.hostContext.getExecutor());
-
-        // Stage E: if D identified a candidate for stealing, attempt to steal it. Return true on successful stealing, false in all other cases
-        leaseToStealFuture.thenComposeAsync((stealThisLease) ->
+        (new PartitionScanner(this.hostContext, (lease) -> this.pump.addPump(lease))).scan(isFirst)
+        .whenCompleteAsync((lease, e) ->
         {
-            return (stealThisLease != null) ? this.hostContext.getLeaseManager().acquireLease(stealThisLease) : CompletableFuture.completedFuture(false);
-        }, this.hostContext.getExecutor())
-                // Stage F: consume results from E and D. Start a pump if a lease was stolen.
-                .thenCombineAsync(leaseToStealFuture, (stealSucceeded, lease) ->
-                {
-                    if (stealSucceeded) {
-                        TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(lease, "Stole lease"));
-                        this.pump.addPump(lease);
+            onPartitionCheckCompleteTestHook();
+
+            // Schedule the next scan unless the future has been cancelled.
+            synchronized (this.scanFutureSynchronizer) {
+                if (!this.scanFuture.isCancelled()) {
+                    int seconds = this.hostContext.getPartitionManagerOptions().getLeaseRenewIntervalInSeconds();
+                    if (isFirst) {
+                    	// After the first pass, wait a larger, random amount of time before doing another scan.
+                    	// The longer wait is to allow as many other instances as possible to establish beachhead leases.
+                    	// The randomness is so that the second pass will be staggered, to minimize contention while
+                    	// instances take multiple unowned leases.
+                    	Random pickWait = new Random();
+                    	seconds += pickWait.nextInt(this.waitStaggerMax);
                     }
-                    return lease;
-                }, this.hostContext.getExecutor())
-                // Stage G: ALWAYS RUN REGARDLESS OF EXCEPTIONS -- log/notify, schedule next scan
-                .whenCompleteAsync((lease, e) ->
-                {
-                    if (e != null) {
-                        Exception notifyWith = (Exception) LoggingUtils.unwrapException(e, null);
-                        if (lease != null) {
-                            TRACE_LOGGER.warn(this.hostContext.withHost("Exception stealing lease for partition " + lease.getPartitionId()), notifyWith);
-                            this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
-                                    EventProcessorHostActionStrings.STEALING_LEASE, lease.getPartitionId());
-                        } else {
-                            TRACE_LOGGER.warn(this.hostContext.withHost("Exception stealing lease"), notifyWith);
-                            this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
-                                    EventProcessorHostActionStrings.STEALING_LEASE, ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
-                        }
-                    }
-
-                    onPartitionCheckCompleteTestHook();
-
-                    // Schedule the next scan unless the future has been cancelled.
-                    synchronized (this.scanFutureSynchronizer) {
-                        if (!this.scanFuture.isCancelled()) {
-                            int seconds = this.hostContext.getPartitionManagerOptions().getLeaseRenewIntervalInSeconds();
-                            this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(), seconds, TimeUnit.SECONDS);
-                            TRACE_LOGGER.debug(this.hostContext.withHost("Scheduling lease scanner in " + seconds));
-                        }
-                    }
-                }, this.hostContext.getExecutor());
-
-        return null;
-    }
-
-    private Lease whichLeaseToSteal(Collection<Lease> stealableLeases, int haveLeaseCount) {
-        HashMap<String, Integer> countsByOwner = countLeasesByOwner(stealableLeases);
-        String biggestOwner = findBiggestOwner(countsByOwner);
-        int biggestCount = countsByOwner.get(biggestOwner); // HASHMAP
-        Lease stealThisLease = null;
-
-        // If the number of leases is a multiple of the number of hosts, then the desired configuration is
-        // that all hosts own the name number of leases, and the difference between the "biggest" owner and
-        // any other is 0.
-        //
-        // If the number of leases is not a multiple of the number of hosts, then the most even configuration
-        // possible is for some hosts to have (leases/hosts) leases and others to have ((leases/hosts) + 1).
-        // For example, for 16 partitions distributed over five hosts, the distribution would be 4, 3, 3, 3, 3,
-        // or any of the possible reorderings.
-        //
-        // In either case, if the difference between this host and the biggest owner is 2 or more, then the
-        // system is not in the most evenly-distributed configuration, so steal one lease from the biggest.
-        // If there is a tie for biggest, findBiggestOwner() picks whichever appears first in the list because
-        // it doesn't really matter which "biggest" is trimmed down.
-        //
-        // Stealing one at a time prevents flapping because it reduces the difference between the biggest and
-        // this host by two at a time. If the starting difference is two or greater, then the difference cannot
-        // end up below 0. This host may become tied for biggest, but it cannot become larger than the host that
-        // it is stealing from.
-
-        if ((biggestCount - haveLeaseCount) >= 2) {
-            for (Lease l : stealableLeases) {
-                if (l.isOwnedBy(biggestOwner)) {
-                    stealThisLease = l;
-                    TRACE_LOGGER.debug(this.hostContext.withHost("Proposed to steal lease for partition " + l.getPartitionId() + " from " + biggestOwner));
-                    break;
+                    this.scanFuture = this.hostContext.getExecutor().schedule(() -> scan(false), seconds, TimeUnit.SECONDS);
+                    TRACE_LOGGER.debug(this.hostContext.withHost("Scheduling lease scanner in " + seconds));
                 }
             }
-        }
-        return stealThisLease;
-    }
+        }, this.hostContext.getExecutor());
 
-    private String findBiggestOwner(HashMap<String, Integer> countsByOwner) {
-        int biggestCount = 0;
-        String biggestOwner = null;
-        for (String owner : countsByOwner.keySet()) {
-            if (countsByOwner.get(owner) > biggestCount) // HASHMAP
-            {
-                biggestCount = countsByOwner.get(owner); // HASHMAP
-                biggestOwner = owner;
-            }
-        }
-        return biggestOwner;
-    }
-
-    private HashMap<String, Integer> countLeasesByOwner(Iterable<Lease> leases) {
-        HashMap<String, Integer> counts = new HashMap<String, Integer>();
-        for (Lease l : leases) {
-            if (counts.containsKey(l.getOwner())) {
-                Integer oldCount = counts.get(l.getOwner()); // HASHMAP
-                counts.put(l.getOwner(), oldCount + 1);
-            } else {
-                counts.put(l.getOwner(), 1);
-            }
-        }
-        for (String owner : counts.keySet()) {
-            TRACE_LOGGER.debug(this.hostContext.withHost("host " + owner + " owns " + counts.get(owner) + " leases")); // HASHMAP
-        }
-        TRACE_LOGGER.debug(this.hostContext.withHost("total hosts in sorted list: " + counts.size()));
-
-        return counts;
+        return null;
     }
 
     // Exception wrapper that buildRetries() uses to indicate that a fatal error has occurred. The chain
@@ -492,14 +328,6 @@ class PartitionManager {
 
         CompletionException getInner() {
             return (CompletionException) this.getCause();
-        }
-    }
-
-    private class BoolWrapper {
-        public boolean value;
-
-        public BoolWrapper(boolean init) {
-            this.value = init;
         }
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManagerOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManagerOptions.java
@@ -26,10 +26,18 @@ public class PartitionManagerOptions {
      * The default timeout for checkpoint operations.
      */
     public final static int DefaultCheckpointTimeoutInSeconds = 120;
+    
+    public final static int DefaultStartupScanDelayInSeconds = 60;
+    public final static int DefaultFastScanIntervalInSeconds = 10;
+    public final static int DefaultSlowScanIntervalInSeconds = 60;
 
     protected int leaseDurationInSeconds = PartitionManagerOptions.DefaultLeaseDurationInSeconds;
     protected int leaseRenewIntervalInSeconds = PartitionManagerOptions.DefaultLeaseRenewIntervalInSeconds;
     protected int checkpointTimeoutInSeconds = PartitionManagerOptions.DefaultCheckpointTimeoutInSeconds;
+    
+    protected int startupScanDelayInSeconds = PartitionManagerOptions.DefaultStartupScanDelayInSeconds;
+    protected int fastScanIntervalInSeconds = PartitionManagerOptions.DefaultFastScanIntervalInSeconds;
+    protected int slowScanIntervalInSeconds = PartitionManagerOptions.DefaultSlowScanIntervalInSeconds;
 
     /***
      * The base class automatically sets members to the static defaults.
@@ -101,5 +109,38 @@ public class PartitionManagerOptions {
             throw new IllegalArgumentException("Checkpoint timeout must be greater than 0");
         }
         this.checkpointTimeoutInSeconds = timeout;
+    }
+    
+    public int getStartupScanDelayInSeconds() {
+    	return this.startupScanDelayInSeconds;
+    }
+    
+    public void setStartupScanDelayInSeconds(int delay) {
+    	if (delay <= 0) {
+    		throw new IllegalArgumentException("Startup scan delay must be greater than 0");
+    	}
+    	this.startupScanDelayInSeconds = delay;
+    }
+    
+    public int getFastScanIntervalInSeconds() {
+    	return this.fastScanIntervalInSeconds;
+    }
+    
+    public void setFastScanIntervalInSeconds(int interval) {
+    	if (interval <= 0) {
+    		throw new IllegalArgumentException("Fast scan interval must be greater than 0");
+    	}
+    	this.fastScanIntervalInSeconds = interval;
+    }
+    
+    public int getSlowScanIntervalInSeconds() {
+    	return this.slowScanIntervalInSeconds;
+    }
+    
+    public void setSlowScanIntervalInSeconds(int interval) {
+    	if (interval <= 0) {
+    		throw new IllegalArgumentException("Slow scan interval must be greater than 0");
+    	}
+    	this.slowScanIntervalInSeconds = interval;
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManagerOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManagerOptions.java
@@ -26,15 +26,15 @@ public class PartitionManagerOptions {
      * The default timeout for checkpoint operations.
      */
     public final static int DefaultCheckpointTimeoutInSeconds = 120;
-    
-    public final static int DefaultStartupScanDelayInSeconds = 60;
-    public final static int DefaultFastScanIntervalInSeconds = 10;
-    public final static int DefaultSlowScanIntervalInSeconds = 60;
+
+    public final static int DefaultStartupScanDelayInSeconds = 30;
+    public final static int DefaultFastScanIntervalInSeconds = 3;
+    public final static int DefaultSlowScanIntervalInSeconds = 5;
 
     protected int leaseDurationInSeconds = PartitionManagerOptions.DefaultLeaseDurationInSeconds;
     protected int leaseRenewIntervalInSeconds = PartitionManagerOptions.DefaultLeaseRenewIntervalInSeconds;
     protected int checkpointTimeoutInSeconds = PartitionManagerOptions.DefaultCheckpointTimeoutInSeconds;
-    
+
     protected int startupScanDelayInSeconds = PartitionManagerOptions.DefaultStartupScanDelayInSeconds;
     protected int fastScanIntervalInSeconds = PartitionManagerOptions.DefaultFastScanIntervalInSeconds;
     protected int slowScanIntervalInSeconds = PartitionManagerOptions.DefaultSlowScanIntervalInSeconds;
@@ -110,37 +110,37 @@ public class PartitionManagerOptions {
         }
         this.checkpointTimeoutInSeconds = timeout;
     }
-    
+
     public int getStartupScanDelayInSeconds() {
-    	return this.startupScanDelayInSeconds;
+        return this.startupScanDelayInSeconds;
     }
-    
+
     public void setStartupScanDelayInSeconds(int delay) {
-    	if (delay <= 0) {
-    		throw new IllegalArgumentException("Startup scan delay must be greater than 0");
-    	}
-    	this.startupScanDelayInSeconds = delay;
+        if (delay <= 0) {
+            throw new IllegalArgumentException("Startup scan delay must be greater than 0");
+        }
+        this.startupScanDelayInSeconds = delay;
     }
-    
+
     public int getFastScanIntervalInSeconds() {
-    	return this.fastScanIntervalInSeconds;
+        return this.fastScanIntervalInSeconds;
     }
-    
+
     public void setFastScanIntervalInSeconds(int interval) {
-    	if (interval <= 0) {
-    		throw new IllegalArgumentException("Fast scan interval must be greater than 0");
-    	}
-    	this.fastScanIntervalInSeconds = interval;
+        if (interval <= 0) {
+            throw new IllegalArgumentException("Fast scan interval must be greater than 0");
+        }
+        this.fastScanIntervalInSeconds = interval;
     }
-    
+
     public int getSlowScanIntervalInSeconds() {
-    	return this.slowScanIntervalInSeconds;
+        return this.slowScanIntervalInSeconds;
     }
-    
+
     public void setSlowScanIntervalInSeconds(int interval) {
-    	if (interval <= 0) {
-    		throw new IllegalArgumentException("Slow scan interval must be greater than 0");
-    	}
-    	this.slowScanIntervalInSeconds = interval;
+        if (interval <= 0) {
+            throw new IllegalArgumentException("Slow scan interval must be greater than 0");
+        }
+        this.slowScanIntervalInSeconds = interval;
     }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
@@ -223,7 +223,7 @@ class PartitionScanner {
         // Extract hosts which own more than the desired count
         ArrayList<String> bigOwners = new ArrayList<String>();
         for (Map.Entry<String, Integer> pair : hostOwns.entrySet()) {
-            if (pair.getValue() > (this.desiredCount + 1)) {
+            if (pair.getValue() > this.desiredCount) {
                 bigOwners.add(pair.getKey());
                 TRACE_LOGGER.info(this.hostContext.withHost("Big owner " + pair.getKey() + " has " + pair.getValue()));
             }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
@@ -5,284 +5,280 @@
 
 package com.microsoft.azure.eventprocessorhost;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Random;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 class PartitionScanner {
-    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionManager.class);
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionScanner.class);
     private static final Random randomizer = new Random();
     private final HostContext hostContext;
     private final Consumer<Lease> addPump;
-    
+    final private ConcurrentHashMap<String, LeaseStateInfo> leasesOwnedByOthers; // updated by acquireExpiredInChunksParallel
     // Populated by getAllLeaseStates()
     private List<LeaseStateInfo> allLeaseStates = null;
-    
     // Values populated by sortLeasesAndCalculateDesiredCount
     private int desiredCount;
     private int unownedCount;
-	final private ConcurrentHashMap<String, LeaseStateInfo> leasesOwnedByOthers; // updated by acquireExpiredInChunksParallel
-	
-	public PartitionScanner(HostContext hostContext, Consumer<Lease> addPump) {
-		this.hostContext = hostContext;
-		this.addPump = addPump;
-		
-		this.desiredCount = 0;
-		this.unownedCount = 0;
-		this.leasesOwnedByOthers = new ConcurrentHashMap<String, LeaseStateInfo>();
-	}
-	
-	public CompletableFuture<Boolean> scan(boolean isFirst) {
-		return getAllLeaseStates()
-			.thenComposeAsync((unused) -> {
-				int ourLeasesCount = sortLeasesAndCalculateDesiredCount(isFirst);
-				return acquireExpiredInChunksParallel(0, this.desiredCount - ourLeasesCount);
-			}, this.hostContext.getExecutor())
-			.thenApplyAsync((remainingNeeded) -> {
-				ArrayList<LeaseStateInfo> stealThese = new ArrayList<LeaseStateInfo>();
-				if (remainingNeeded > 0) {
-					TRACE_LOGGER.info(this.hostContext.withHost("Looking to steal: " + remainingNeeded));
-					stealThese = findLeasesToSteal(remainingNeeded);
-				}
-				return stealThese;
-			}, this.hostContext.getExecutor())
-			.thenComposeAsync((stealThese) -> stealLeases(stealThese), this.hostContext.getExecutor())
-			.whenCompleteAsync((didSteal, e) -> {
-				if (e != null) {
-					StringBuilder outAction = new StringBuilder();
-					Exception notifyWith = (Exception)LoggingUtils.unwrapException(e, outAction);
-					TRACE_LOGGER.warn(this.hostContext.withHost("Exception scanning leases"), notifyWith);
-					this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith, outAction.toString(),
-							ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
-				}
-			}, this.hostContext.getExecutor());
-	}
-	
-	
-	private CompletableFuture<Void> getAllLeaseStates() {
-		return this.hostContext.getLeaseManager().getAllLeasesStateInfo()
-			.thenAcceptAsync((states) -> { this.allLeaseStates = states; Collections.sort(this.allLeaseStates); }, this.hostContext.getExecutor());
-	}
 
-	private int sortLeasesAndCalculateDesiredCount(boolean isFirst) {
-		TRACE_LOGGER.info(this.hostContext.withHost("Accounting input: allLeaseStates size is " + this.allLeaseStates.size()));
-		
-		HashSet<String> uniqueOwners = new HashSet<String>();
-		uniqueOwners.add(this.hostContext.getHostName());
-		int ourLeasesCount = 0;
-		for (int i = 0; i < this.allLeaseStates.size(); i++) {
-			LeaseStateInfo info = this.allLeaseStates.get(i);
-			boolean ownedByUs = info.isOwned() ? (info.getOwner().compareTo(this.hostContext.getHostName()) == 0) : false;
-			if (info.isOwned()) {
-				uniqueOwners.add(info.getOwner());
-			} else {
-				this.unownedCount++;
-			}
-			if (ownedByUs) {
-				ourLeasesCount++;
-			} else if (info.isOwned()) {
-				this.leasesOwnedByOthers.put(info.getPartitionId(), info);
-			}
-		}
-		int hostCount = uniqueOwners.size();
-		int countPerHost = this.allLeaseStates.size() / hostCount;
-		this.desiredCount = isFirst ? 1 : countPerHost;
-		if (!isFirst && (this.unownedCount > 0) && (this.unownedCount < hostCount) && ((this.allLeaseStates.size() % hostCount) != 0)) {
-			// Distribute leftovers.
-			this.desiredCount++;
-		}
+    PartitionScanner(HostContext hostContext, Consumer<Lease> addPump) {
+        this.hostContext = hostContext;
+        this.addPump = addPump;
 
-		ArrayList<String> sortedHosts = new ArrayList<String>(uniqueOwners);
-		Collections.sort(sortedHosts);
-		int hostOrdinal = -1;
-		int startingPoint = 0;
-		if (isFirst) {
-			// If the entire system is starting up, the list of hosts is probably not complete and we can't really
-			// compute a meaningful hostOrdinal. But we only want hostOrdinal to calculate startingPoint. Instead,
-			// just randomly select a startingPoint.
-			startingPoint = PartitionScanner.randomizer.nextInt(this.allLeaseStates.size());
-		} else {
-			for (hostOrdinal = 0; hostOrdinal < sortedHosts.size(); hostOrdinal++) {
-				if (sortedHosts.get(hostOrdinal).compareTo(this.hostContext.getHostName()) == 0) {
-					break;
-				}
-			}
-			startingPoint = countPerHost * hostOrdinal;
-		}
-		// Rotate allLeaseStates
-		TRACE_LOGGER.info(this.hostContext.withHost("Host ordinal: " + hostOrdinal + "  Rotating leases to start at " + startingPoint));
-		if (startingPoint != 0) {
-			ArrayList<LeaseStateInfo> rotatedList = new ArrayList<LeaseStateInfo>(this.allLeaseStates.size());
-			for (int j = 0; j < this.allLeaseStates.size(); j++) {
-				rotatedList.add(this.allLeaseStates.get((j + startingPoint) % this.allLeaseStates.size()));
-			}
-			this.allLeaseStates = rotatedList;
-		}
-		
-		TRACE_LOGGER.info(this.hostContext.withHost("Host count is " + hostCount + "  Desired owned count is " + this.desiredCount));
-		TRACE_LOGGER.info(this.hostContext.withHost("ourLeasesCount " + ourLeasesCount + "  leasesOwnedByOthers " + this.leasesOwnedByOthers.size()
-		 	+ " unowned " + unownedCount));
-		
-		return ourLeasesCount;
-	}
-	
-	private CompletableFuture<List<LeaseStateInfo>> findExpiredLeases(int startAt, int endAt) {
-		final ArrayList<LeaseStateInfo> expiredLeases = new ArrayList<LeaseStateInfo>();
-		TRACE_LOGGER.info(this.hostContext.withHost("Finding expired leases from '" + this.allLeaseStates.get(startAt).getPartitionId() + "'[" + startAt + "] up to '" +
-				((endAt < this.allLeaseStates.size()) ? this.allLeaseStates.get(endAt).getPartitionId() : "end") + "'[" + endAt + "]"));
-		
-		for (LeaseStateInfo info : this.allLeaseStates.subList(startAt, endAt)) {
-			if (!info.isOwned()) {
-				expiredLeases.add(info);
-			}
-		}
+        this.desiredCount = 0;
+        this.unownedCount = 0;
+        this.leasesOwnedByOthers = new ConcurrentHashMap<String, LeaseStateInfo>();
+    }
 
-		TRACE_LOGGER.info(this.hostContext.withHost("Found in range: " + expiredLeases.size()));
-		return CompletableFuture.completedFuture(expiredLeases);
-	}
+    public CompletableFuture<Boolean> scan(boolean isFirst) {
+        return getAllLeaseStates()
+                .thenComposeAsync((unused) -> {
+                    int ourLeasesCount = sortLeasesAndCalculateDesiredCount(isFirst);
+                    return acquireExpiredInChunksParallel(0, this.desiredCount - ourLeasesCount);
+                }, this.hostContext.getExecutor())
+                .thenApplyAsync((remainingNeeded) -> {
+                    ArrayList<LeaseStateInfo> stealThese = new ArrayList<LeaseStateInfo>();
+                    if (remainingNeeded > 0) {
+                        TRACE_LOGGER.info(this.hostContext.withHost("Looking to steal: " + remainingNeeded));
+                        stealThese = findLeasesToSteal(remainingNeeded);
+                    }
+                    return stealThese;
+                }, this.hostContext.getExecutor())
+                .thenComposeAsync((stealThese) -> stealLeases(stealThese), this.hostContext.getExecutor())
+                .whenCompleteAsync((didSteal, e) -> {
+                    if (e != null) {
+                        StringBuilder outAction = new StringBuilder();
+                        Exception notifyWith = (Exception) LoggingUtils.unwrapException(e, outAction);
+                        TRACE_LOGGER.warn(this.hostContext.withHost("Exception scanning leases"), notifyWith);
+                        this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith, outAction.toString(),
+                                ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
+                    }
+                }, this.hostContext.getExecutor());
+    }
 
-	private CompletableFuture<Integer> acquireExpiredInChunksParallel(int startAt, int needed) {
-		CompletableFuture<Integer> resultFuture = CompletableFuture.completedFuture(needed);
-		if (startAt < this.allLeaseStates.size()) {
-			TRACE_LOGGER.info(this.hostContext.withHost("Examining chunk at '" + this.allLeaseStates.get(startAt).getPartitionId() + "'[" + startAt + "] need " + needed));
-		} else {
-			TRACE_LOGGER.info(this.hostContext.withHost("Examining chunk skipping, startAt is off end: " + startAt));
-		}
-		
-		if ((needed > 0) && (this.unownedCount > 0) && (startAt < this.allLeaseStates.size())) {
-			final AtomicInteger runningNeeded = new AtomicInteger(needed);
-			final int endAt = Math.min(startAt + needed, this.allLeaseStates.size());
-			
-			resultFuture = findExpiredLeases(startAt, endAt)
-				.thenComposeAsync((getThese) -> {
-						CompletableFuture<Void> acquireFuture = CompletableFuture.completedFuture(null);
-						if (getThese.size() > 0) {
-							ArrayList<CompletableFuture<Void>> getFutures = new ArrayList<CompletableFuture<Void>>();
-							for (LeaseStateInfo info : getThese) {
-								final LeaseStateInfo workingInfo = info;
-								CompletableFuture<Void> getOneFuture = this.hostContext.getLeaseManager().getLease(workingInfo.getPartitionId())
-									.thenComposeAsync((lease) -> {
-										workingInfo.setLease(lease);
-										return this.hostContext.getLeaseManager().acquireLease(lease);
-									}, this.hostContext.getExecutor())
-									.thenAcceptAsync((acquired) -> {
-										if (acquired) {
-											runningNeeded.decrementAndGet();
-											TRACE_LOGGER.info(this.hostContext.withHostAndPartition(workingInfo.getPartitionId(), "Acquired unowned/expired"));
-											this.addPump.accept(workingInfo.getLease());
-										} else {
-											this.leasesOwnedByOthers.put(workingInfo.getPartitionId(), workingInfo);
-										}
-									}, this.hostContext.getExecutor());
-								getFutures.add(getOneFuture);
-							}
-							CompletableFuture<?>[] dummy = new CompletableFuture<?>[getFutures.size()];
-							acquireFuture = CompletableFuture.allOf(getFutures.toArray(dummy));
-						}
-						return acquireFuture;
-					}, this.hostContext.getExecutor())
-				.handleAsync((empty, e) -> {
-						// log/notify if exception occurred, then swallow exception and continue with next chunk
-						if (e != null) {
-                            Exception notifyWith = (Exception)LoggingUtils.unwrapException(e, null);
+    private CompletableFuture<Void> getAllLeaseStates() {
+        return this.hostContext.getLeaseManager().getAllLeasesStateInfo()
+                .thenAcceptAsync((states) -> {
+                    this.allLeaseStates = states;
+                    Collections.sort(this.allLeaseStates);
+                }, this.hostContext.getExecutor());
+    }
+
+    private int sortLeasesAndCalculateDesiredCount(boolean isFirst) {
+        TRACE_LOGGER.info(this.hostContext.withHost("Accounting input: allLeaseStates size is " + this.allLeaseStates.size()));
+
+        HashSet<String> uniqueOwners = new HashSet<String>();
+        uniqueOwners.add(this.hostContext.getHostName());
+        int ourLeasesCount = 0;
+        this.unownedCount = 0;
+        for (LeaseStateInfo info : this.allLeaseStates) {
+            boolean ownedByUs = info.isOwned() && info.getOwner() != null && (info.getOwner().compareTo(this.hostContext.getHostName()) == 0);
+            if (info.isOwned() && info.getOwner() != null) {
+                uniqueOwners.add(info.getOwner());
+            } else {
+                this.unownedCount++;
+            }
+            if (ownedByUs) {
+                ourLeasesCount++;
+            } else if (info.isOwned()) {
+                this.leasesOwnedByOthers.put(info.getPartitionId(), info);
+            }
+        }
+        int hostCount = uniqueOwners.size();
+        int countPerHost = this.allLeaseStates.size() / hostCount;
+        this.desiredCount = isFirst ? 1 : countPerHost;
+        if (!isFirst && (this.unownedCount > 0) && (this.unownedCount < hostCount) && ((this.allLeaseStates.size() % hostCount) != 0)) {
+            // Distribute leftovers.
+            this.desiredCount++;
+        }
+
+        ArrayList<String> sortedHosts = new ArrayList<String>(uniqueOwners);
+        Collections.sort(sortedHosts);
+        int hostOrdinal = -1;
+        int startingPoint = 0;
+        if (isFirst) {
+            // If the entire system is starting up, the list of hosts is probably not complete and we can't really
+            // compute a meaningful hostOrdinal. But we only want hostOrdinal to calculate startingPoint. Instead,
+            // just randomly select a startingPoint.
+            startingPoint = PartitionScanner.randomizer.nextInt(this.allLeaseStates.size());
+        } else {
+            for (hostOrdinal = 0; hostOrdinal < sortedHosts.size(); hostOrdinal++) {
+                if (sortedHosts.get(hostOrdinal).compareTo(this.hostContext.getHostName()) == 0) {
+                    break;
+                }
+            }
+            startingPoint = countPerHost * hostOrdinal;
+        }
+        // Rotate allLeaseStates
+        TRACE_LOGGER.info(this.hostContext.withHost("Host ordinal: " + hostOrdinal + "  Rotating leases to start at " + startingPoint));
+        if (startingPoint != 0) {
+            ArrayList<LeaseStateInfo> rotatedList = new ArrayList<LeaseStateInfo>(this.allLeaseStates.size());
+            for (int j = 0; j < this.allLeaseStates.size(); j++) {
+                rotatedList.add(this.allLeaseStates.get((j + startingPoint) % this.allLeaseStates.size()));
+            }
+            this.allLeaseStates = rotatedList;
+        }
+
+        TRACE_LOGGER.info(this.hostContext.withHost("Host count is " + hostCount + "  Desired owned count is " + this.desiredCount));
+        TRACE_LOGGER.info(this.hostContext.withHost("ourLeasesCount " + ourLeasesCount + "  leasesOwnedByOthers " + this.leasesOwnedByOthers.size()
+                + " unowned " + unownedCount));
+
+        return ourLeasesCount;
+    }
+
+    private CompletableFuture<List<LeaseStateInfo>> findExpiredLeases(int startAt, int endAt) {
+        final ArrayList<LeaseStateInfo> expiredLeases = new ArrayList<LeaseStateInfo>();
+        TRACE_LOGGER.info(this.hostContext.withHost("Finding expired leases from '" + this.allLeaseStates.get(startAt).getPartitionId() + "'[" + startAt + "] up to '" +
+                ((endAt < this.allLeaseStates.size()) ? this.allLeaseStates.get(endAt).getPartitionId() : "end") + "'[" + endAt + "]"));
+
+        for (LeaseStateInfo info : this.allLeaseStates.subList(startAt, endAt)) {
+            if (!info.isOwned()) {
+                expiredLeases.add(info);
+            }
+        }
+
+        TRACE_LOGGER.info(this.hostContext.withHost("Found in range: " + expiredLeases.size()));
+        return CompletableFuture.completedFuture(expiredLeases);
+    }
+
+    private CompletableFuture<Integer> acquireExpiredInChunksParallel(int startAt, int needed) {
+        CompletableFuture<Integer> resultFuture = CompletableFuture.completedFuture(needed);
+        if (startAt < this.allLeaseStates.size()) {
+            TRACE_LOGGER.info(this.hostContext.withHost("Examining chunk at '" + this.allLeaseStates.get(startAt).getPartitionId() + "'[" + startAt + "] need " + needed));
+        } else {
+            TRACE_LOGGER.info(this.hostContext.withHost("Examining chunk skipping, startAt is off end: " + startAt));
+        }
+
+        if ((needed > 0) && (this.unownedCount > 0) && (startAt < this.allLeaseStates.size())) {
+            final AtomicInteger runningNeeded = new AtomicInteger(needed);
+            final int endAt = Math.min(startAt + needed, this.allLeaseStates.size());
+
+            resultFuture = findExpiredLeases(startAt, endAt)
+                    .thenComposeAsync((getThese) -> {
+                        CompletableFuture<Void> acquireFuture = CompletableFuture.completedFuture(null);
+                        if (getThese.size() > 0) {
+                            ArrayList<CompletableFuture<Void>> getFutures = new ArrayList<CompletableFuture<Void>>();
+                            for (LeaseStateInfo info : getThese) {
+                                final LeaseStateInfo workingInfo = info;
+                                CompletableFuture<Void> getOneFuture = this.hostContext.getLeaseManager().getLease(workingInfo.getPartitionId())
+                                        .thenComposeAsync((lease) -> {
+                                            workingInfo.setLease(lease);
+                                            return this.hostContext.getLeaseManager().acquireLease(lease);
+                                        }, this.hostContext.getExecutor())
+                                        .thenAcceptAsync((acquired) -> {
+                                            if (acquired) {
+                                                runningNeeded.decrementAndGet();
+                                                TRACE_LOGGER.info(this.hostContext.withHostAndPartition(workingInfo.getPartitionId(), "Acquired unowned/expired"));
+                                                if (this.leasesOwnedByOthers.containsKey(workingInfo.getPartitionId())) {
+                                                    this.leasesOwnedByOthers.remove(workingInfo.getPartitionId());
+                                                    this.unownedCount--;
+                                                }
+                                                this.addPump.accept(workingInfo.getLease());
+                                            } else {
+                                                this.leasesOwnedByOthers.put(workingInfo.getPartitionId(), workingInfo);
+                                            }
+                                        }, this.hostContext.getExecutor());
+                                getFutures.add(getOneFuture);
+                            }
+                            CompletableFuture<?>[] dummy = new CompletableFuture<?>[getFutures.size()];
+                            acquireFuture = CompletableFuture.allOf(getFutures.toArray(dummy));
+                        }
+                        return acquireFuture;
+                    }, this.hostContext.getExecutor())
+                    .handleAsync((empty, e) -> {
+                        // log/notify if exception occurred, then swallow exception and continue with next chunk
+                        if (e != null) {
+                            Exception notifyWith = (Exception) LoggingUtils.unwrapException(e, null);
                             TRACE_LOGGER.warn(this.hostContext.withHost("Failure getting/acquiring lease, continuing"), notifyWith);
                             this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
                                     EventProcessorHostActionStrings.CHECKING_LEASES, ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
-						}
-						return null;
-					}, this.hostContext.getExecutor())
-				.thenComposeAsync((unused) -> {
-					return acquireExpiredInChunksParallel(endAt, runningNeeded.get());
-					}, this.hostContext.getExecutor());
-		} else {
-			TRACE_LOGGER.info(this.hostContext.withHost("Short circuit: needed is 0, unowned is 0, or off end"));
-		}
-		
-		return resultFuture;
-	}
+                        }
+                        return null;
+                    }, this.hostContext.getExecutor())
+                    .thenComposeAsync((unused) -> acquireExpiredInChunksParallel(endAt, runningNeeded.get()), this.hostContext.getExecutor());
+        } else {
+            TRACE_LOGGER.info(this.hostContext.withHost("Short circuit: needed is 0, unowned is 0, or off end"));
+        }
 
-	private ArrayList<LeaseStateInfo> findLeasesToSteal(int stealAsk) {
-		// Generate a map of hostnames and owned counts.
-		HashMap<String, Integer> hostOwns = new HashMap<String, Integer>();
-		for (LeaseStateInfo info : this.leasesOwnedByOthers.values()) {
-			if (hostOwns.containsKey(info.getOwner())) {
-				int newCount = hostOwns.get(info.getOwner()) + 1;
-				hostOwns.put(info.getOwner(), newCount);
-			} else {
-				hostOwns.put(info.getOwner(), 1);
-			}
-		}
-		
-		// Extract hosts which own more than the desired count
-		ArrayList<String> bigOwners = new ArrayList<String>();
-		for (Map.Entry<String, Integer> pair : hostOwns.entrySet()) {
-			if (pair.getValue() > (this.desiredCount + 1)) {
-				bigOwners.add(pair.getKey());
-				TRACE_LOGGER.info(this.hostContext.withHost("Big owner " + pair.getKey() + " has " + pair.getValue()));
-			}
-		}
+        return resultFuture;
+    }
 
-		ArrayList<LeaseStateInfo> stealInfos = new ArrayList<LeaseStateInfo>();
+    private ArrayList<LeaseStateInfo> findLeasesToSteal(int stealAsk) {
+        // Generate a map of hostnames and owned counts.
+        HashMap<String, Integer> hostOwns = new HashMap<String, Integer>();
+        for (LeaseStateInfo info : this.leasesOwnedByOthers.values()) {
+            if (hostOwns.containsKey(info.getOwner())) {
+                int newCount = hostOwns.get(info.getOwner()) + 1;
+                hostOwns.put(info.getOwner(), newCount);
+            } else {
+                hostOwns.put(info.getOwner(), 1);
+            }
+        }
 
-		if (bigOwners.size() > 0) {
-			// Randomly pick one of the big owners
-			String bigVictim = bigOwners.get(PartitionScanner.randomizer.nextInt(bigOwners.size()));
-			int victimExtra = hostOwns.get(bigVictim) - this.desiredCount - 1;
-			int stealCount = Math.min(victimExtra, stealAsk);
-			TRACE_LOGGER.info(this.hostContext.withHost("Stealing " + stealCount + " from " + bigVictim));
-			
-			// Grab stealCount partitions owned by bigVictim and return the infos.
-			for (LeaseStateInfo candidate : this.allLeaseStates) {
-				if (candidate.getOwner().compareTo(bigVictim) == 0) {
-					stealInfos.add(candidate);
-					if (stealInfos.size() >= stealCount) {
-						break;
-					}
-				}
-			}
-		} else {
-			TRACE_LOGGER.info(this.hostContext.withHost("No big owners found, skipping steal"));
-		}
-		
-		return stealInfos;
-	}
-	
-	private CompletableFuture<Boolean> stealLeases(List<LeaseStateInfo> stealThese) {
-		CompletableFuture<Boolean> allSteals = CompletableFuture.completedFuture(false);
-		
-		if (stealThese.size() > 0) {
-			ArrayList<CompletableFuture<Void>> steals = new ArrayList<CompletableFuture<Void>>();
-			for (LeaseStateInfo info : stealThese) {
-				final LeaseStateInfo workingInfo = info;
-				CompletableFuture<Void> oneSteal = this.hostContext.getLeaseManager().getLease(workingInfo.getPartitionId())
-					.thenComposeAsync((lease) -> {
-						workingInfo.setLease(lease);
-						return this.hostContext.getLeaseManager().acquireLease(lease);
-					}, this.hostContext.getExecutor())
-					.thenAcceptAsync((acquired) -> {
-						if (acquired) {
-							TRACE_LOGGER.info(this.hostContext.withHostAndPartition(workingInfo.getPartitionId(), "Stole lease"));
-							this.addPump.accept(workingInfo.getLease());
-						}
-					}, this.hostContext.getExecutor());
-				steals.add(oneSteal);
-			}
-			
-			CompletableFuture<?> dummy[] = new CompletableFuture<?>[steals.size()];
-			allSteals = CompletableFuture.allOf(steals.toArray(dummy)).thenApplyAsync((empty) -> true, this.hostContext.getExecutor());
-		}
-		
-		return allSteals;
-	}
+        // Extract hosts which own more than the desired count
+        ArrayList<String> bigOwners = new ArrayList<String>();
+        for (Map.Entry<String, Integer> pair : hostOwns.entrySet()) {
+            if (pair.getValue() > (this.desiredCount + 1)) {
+                bigOwners.add(pair.getKey());
+                TRACE_LOGGER.info(this.hostContext.withHost("Big owner " + pair.getKey() + " has " + pair.getValue()));
+            }
+        }
+
+        ArrayList<LeaseStateInfo> stealInfos = new ArrayList<LeaseStateInfo>();
+
+        if (bigOwners.size() > 0) {
+            // Randomly pick one of the big owners
+            String bigVictim = bigOwners.get(PartitionScanner.randomizer.nextInt(bigOwners.size()));
+            int victimExtra = hostOwns.get(bigVictim) - this.desiredCount - 1;
+            int stealCount = Math.min(victimExtra, stealAsk);
+            TRACE_LOGGER.info(this.hostContext.withHost("Stealing " + stealCount + " from " + bigVictim));
+
+            // Grab stealCount partitions owned by bigVictim and return the infos.
+            for (LeaseStateInfo candidate : this.allLeaseStates) {
+                if (candidate.getOwner().compareTo(bigVictim) == 0) {
+                    stealInfos.add(candidate);
+                    if (stealInfos.size() >= stealCount) {
+                        break;
+                    }
+                }
+            }
+        } else {
+            TRACE_LOGGER.info(this.hostContext.withHost("No big owners found, skipping steal"));
+        }
+
+        return stealInfos;
+    }
+
+    private CompletableFuture<Boolean> stealLeases(List<LeaseStateInfo> stealThese) {
+        CompletableFuture<Boolean> allSteals = CompletableFuture.completedFuture(false);
+
+        if (stealThese.size() > 0) {
+            ArrayList<CompletableFuture<Void>> steals = new ArrayList<CompletableFuture<Void>>();
+            for (LeaseStateInfo info : stealThese) {
+                final LeaseStateInfo workingInfo = info;
+                CompletableFuture<Void> oneSteal = this.hostContext.getLeaseManager().getLease(workingInfo.getPartitionId())
+                        .thenComposeAsync((lease) -> {
+                            workingInfo.setLease(lease);
+                            return this.hostContext.getLeaseManager().acquireLease(lease);
+                        }, this.hostContext.getExecutor())
+                        .thenAcceptAsync((acquired) -> {
+                            if (acquired) {
+                                TRACE_LOGGER.info(this.hostContext.withHostAndPartition(workingInfo.getPartitionId(), "Stole lease"));
+                                this.addPump.accept(workingInfo.getLease());
+                            }
+                        }, this.hostContext.getExecutor());
+                steals.add(oneSteal);
+            }
+
+            CompletableFuture<?> dummy[] = new CompletableFuture<?>[steals.size()];
+            allSteals = CompletableFuture.allOf(steals.toArray(dummy)).thenApplyAsync((empty) -> true, this.hostContext.getExecutor());
+        }
+
+        return allSteals;
+    }
 }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+
+package com.microsoft.azure.eventprocessorhost;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PartitionScanner {
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionManager.class);
+    private final HostContext hostContext;
+    private final Consumer<Lease> addPump;
+    
+    // Populated by getAllLeases()
+    private ArrayList<Lease> allLeases = null;
+    
+    // Values populated by initialCalcAndSort
+    private int hostCount;
+	final private AtomicInteger ourLeasesCount; // updated by acquireExpiredInChunksParallel
+	final private ConcurrentHashMap<String, Lease> leasesOwnedByOthers; // updated by acquireExpiredInChunksParallel
+	
+	public PartitionScanner(HostContext hostContext, Consumer<Lease> addPump) {
+		this.hostContext = hostContext;
+		this.addPump = addPump;
+		
+		this.ourLeasesCount = new AtomicInteger();
+		this.leasesOwnedByOthers = new ConcurrentHashMap<String, Lease>();
+	}
+	
+	public CompletableFuture<Lease> scan(boolean isFirst) {
+		return getAllLeases()
+			.thenApplyAsync((empty) -> { return initialCalcAndSort(isFirst); }, this.hostContext.getExecutor())
+			.thenComposeAsync((desiredLeaseCount) -> acquireExpiredInChunksParallel(0, desiredLeaseCount - ourLeasesCount.get()), this.hostContext.getExecutor())
+			.thenApplyAsync((remainingNeeded) -> { return (remainingNeeded > 0) ? findLeaseToSteal() : null; }, this.hostContext.getExecutor())
+			.thenComposeAsync((leaseToSteal) -> stealALease(leaseToSteal), this.hostContext.getExecutor())
+	        .whenCompleteAsync((lease, e) -> {
+		            if (e != null) {
+		                Exception notifyWith = (Exception) LoggingUtils.unwrapException(e, null);
+		                if (lease != null) {
+		                    TRACE_LOGGER.warn(this.hostContext.withHost("Exception stealing lease for partition " + lease.getPartitionId()), notifyWith);
+		                    this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
+		                            EventProcessorHostActionStrings.STEALING_LEASE, lease.getPartitionId());
+		                } else {
+		                    TRACE_LOGGER.warn(this.hostContext.withHost("Exception stealing lease"), notifyWith);
+		                    this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
+		                            EventProcessorHostActionStrings.STEALING_LEASE, ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
+		                }
+		            }
+		        }, this.hostContext.getExecutor());
+	}
+	
+	private CompletableFuture<Void> getAllLeases() {
+		return this.hostContext.getLeaseManager().getAllLeases().thenAcceptAsync((leaseList) -> { this.allLeases = new ArrayList<Lease>(leaseList); });
+	}
+	
+	private int initialCalcAndSort(boolean isFirst) {
+		HashSet<String> uniqueOwners = new HashSet<String>();
+		for (Lease l : this.allLeases) {
+			String owner = l.getOwner();
+			if ((owner != null) && !owner.isEmpty())
+			{
+				uniqueOwners.add(owner);
+			}
+			if (l.isOwnedBy(this.hostContext.getHostName())) {
+				this.ourLeasesCount.getAndIncrement();
+			} else {
+				this.leasesOwnedByOthers.put(l.getPartitionId(), l);
+			}
+		}
+		this.hostCount = uniqueOwners.size();
+		return isFirst ? 1 : (this.allLeases.size() / this.hostCount);
+	}
+	
+	private CompletableFuture<List<Lease>> findExpiredLeases(int startAt, int endAt) {
+		ArrayList<Lease> expiredLeases = new ArrayList<Lease>();
+		
+		ArrayList<CompletableFuture<Void>> leaseStateFutures = new ArrayList<CompletableFuture<Void>>();
+		for (Lease l : this.allLeases.subList(startAt, endAt)) {
+			final Lease workingLease = l;
+			CompletableFuture<Void> isExpiredFuture = workingLease.isExpired()
+    			.thenAcceptAsync((isExpired) -> {
+    				if (isExpired) {
+    					expiredLeases.add(workingLease);
+    				}
+    			}, this.hostContext.getExecutor());
+			leaseStateFutures.add(isExpiredFuture);
+		}
+
+        CompletableFuture<?>[] dummy = new CompletableFuture<?>[leaseStateFutures.size()];
+        return CompletableFuture.allOf(leaseStateFutures.toArray(dummy)).thenApplyAsync((empty) -> { return expiredLeases; }, this.hostContext.getExecutor());
+	}
+	
+	private CompletableFuture<Integer> acquireExpiredInChunksParallel(int startAt, int needed) {
+		CompletableFuture<Integer> resultFuture = CompletableFuture.completedFuture(needed);
+		
+		if ((needed > 0) && (startAt < this.allLeases.size())) {
+			final AtomicInteger runningNeeded = new AtomicInteger(needed);
+			int endAt = Math.min(startAt + needed, this.allLeases.size());
+			
+			resultFuture = findExpiredLeases(startAt, endAt)
+				.thenComposeAsync((getThese) -> {
+						CompletableFuture<Void> acquireFuture = CompletableFuture.completedFuture(null);
+						if (getThese.size() > 0) {
+							ArrayList<CompletableFuture<Void>> getFutures = new ArrayList<CompletableFuture<Void>>();
+							for (Lease l : getThese) {
+								final Lease workingLease = l;
+								CompletableFuture<Void> getOneFuture = this.hostContext.getLeaseManager().acquireLease(workingLease)
+									.thenAcceptAsync((acquired) -> {
+										if (acquired) {
+											runningNeeded.decrementAndGet();
+											this.ourLeasesCount.incrementAndGet();
+											this.addPump.accept(workingLease);
+										} else {
+											this.leasesOwnedByOthers.put(workingLease.getPartitionId(), workingLease);
+										}
+									}, this.hostContext.getExecutor());
+								getFutures.add(getOneFuture);
+							}
+							CompletableFuture<?>[] dummy = new CompletableFuture<?>[getFutures.size()];
+							acquireFuture = CompletableFuture.allOf(getFutures.toArray(dummy));
+						}
+						return acquireFuture;
+					}, this.hostContext.getExecutor())
+				.handleAsync((empty, e) -> {
+						// log/notify if exception occurred, then swallow exception and continue with next chunk
+						if (e != null) {
+                            Exception notifyWith = (Exception)LoggingUtils.unwrapException(e, null);
+                            TRACE_LOGGER.warn(this.hostContext.withHost("Failure getting/acquiring lease, skipping"), notifyWith);
+                            this.hostContext.getEventProcessorOptions().notifyOfException(this.hostContext.getHostName(), notifyWith,
+                                    EventProcessorHostActionStrings.CHECKING_LEASES, ExceptionReceivedEventArgs.NO_ASSOCIATED_PARTITION);
+						}
+						return null;
+					}, this.hostContext.getExecutor())
+				.thenComposeAsync((unused) -> {
+					return acquireExpiredInChunksParallel(endAt, runningNeeded.get());
+					}, this.hostContext.getExecutor());
+		}
+		
+		return resultFuture;
+	}
+	
+	private Lease findLeaseToSteal()
+	{
+        HashMap<String, Integer> countsByOwner = new HashMap<String, Integer>();
+        for (Lease l : this.leasesOwnedByOthers.values()) {
+            if (countsByOwner.containsKey(l.getOwner())) {
+                Integer oldCount = countsByOwner.get(l.getOwner());
+                countsByOwner.put(l.getOwner(), oldCount + 1);
+            } else {
+                countsByOwner.put(l.getOwner(), 1);
+            }
+        }
+        for (String owner : countsByOwner.keySet()) {
+            TRACE_LOGGER.debug(this.hostContext.withHost("host " + owner + " owns " + countsByOwner.get(owner) + " leases")); // HASHMAP
+        }
+        TRACE_LOGGER.debug(this.hostContext.withHost("total hosts in sorted list: " + countsByOwner.size()));
+
+        int biggestCount = 0;
+        String biggestOwner = null;
+        for (String owner : countsByOwner.keySet()) {
+            if (countsByOwner.get(owner) > biggestCount) {
+                biggestCount = countsByOwner.get(owner);
+                biggestOwner = owner;
+            }
+        }
+
+        // If the number of leases is a multiple of the number of hosts, then the desired configuration is
+        // that all hosts own the name number of leases, and the difference between the "biggest" owner and
+        // any other is 0.
+        //
+        // If the number of leases is not a multiple of the number of hosts, then the most even configuration
+        // possible is for some hosts to have (leases/hosts) leases and others to have ((leases/hosts) + 1).
+        // For example, for 16 partitions distributed over five hosts, the distribution would be 4, 3, 3, 3, 3,
+        // or any of the possible reorderings.
+        //
+        // In either case, if the difference between this host and the biggest owner is 2 or more, then the
+        // system is not in the most evenly-distributed configuration, so steal one lease from the biggest.
+        // If there is a tie for biggest, findBiggestOwner() picks whichever appears first in the list because
+        // it doesn't really matter which "biggest" is trimmed down.
+        //
+        // Stealing one at a time prevents flapping because it reduces the difference between the biggest and
+        // this host by two at a time. If the starting difference is two or greater, then the difference cannot
+        // end up below 0. This host may become tied for biggest, but it cannot become larger than the host that
+        // it is stealing from.
+
+        Lease stealThisLease = null;
+        if ((biggestCount - this.ourLeasesCount.get()) >= 2) {
+            for (Lease l : this.leasesOwnedByOthers.values()) {
+                if (l.isOwnedBy(biggestOwner)) {
+                    stealThisLease = l;
+                    TRACE_LOGGER.debug(this.hostContext.withHost("Proposed to steal lease for partition " + l.getPartitionId() + " from " + biggestOwner));
+                    break;
+                }
+            }
+        }
+        return stealThisLease;
+	}
+	
+	private CompletableFuture<Lease> stealALease(Lease leaseToSteal)
+	{
+		CompletableFuture<Lease> stealResult = CompletableFuture.completedFuture(null);
+		
+		if (leaseToSteal != null) {
+			stealResult = this.hostContext.getLeaseManager().acquireLease(leaseToSteal)
+				.thenApplyAsync((acquired) -> {
+						if (acquired) {
+	                        TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(leaseToSteal, "Stole lease"));
+							this.addPump.accept(leaseToSteal);
+						}
+						return acquired ? leaseToSteal : null;
+					}, this.hostContext.getExecutor());
+		}
+		
+		return stealResult;
+	}
+}

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionScanner.java
@@ -240,7 +240,7 @@ class PartitionScanner {
 
             // Grab stealCount partitions owned by bigVictim and return the infos.
             for (LeaseStateInfo candidate : this.allLeaseStates) {
-                if (candidate.getOwner().compareTo(bigVictim) == 0) {
+                if (candidate.getOwner() != null && candidate.getOwner().compareTo(bigVictim) == 0) {
                     stealInfos.add(candidate);
                     if (stealInfos.size() >= stealCount) {
                         break;

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PartitionManagerTest.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PartitionManagerTest.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.junit.Test;
 import static org.junit.Assert.assertTrue;
 
 public class PartitionManagerTest {
@@ -30,7 +31,7 @@ public class PartitionManagerTest {
     private int maxChecks;
     private boolean shuttingDown;
 
-    //@Test
+    @Test
     public void partitionBalancingExactMultipleTest() throws Exception {
         TestUtilities.log("partitionBalancingExactMultipleTest");
 
@@ -64,7 +65,7 @@ public class PartitionManagerTest {
         TestUtilities.log("DONE");
     }
 
-    //@Test
+    @Test
     public void partitionBalancingUnevenTest() throws Exception {
         TestUtilities.log("partitionBalancingUnevenTest");
 
@@ -98,7 +99,7 @@ public class PartitionManagerTest {
         TestUtilities.log("DONE");
     }
 
-    //@Test
+    @Test
     public void partitionRebalancingTest() throws Exception {
         TestUtilities.log("partitionRebalancingTest");
 
@@ -175,7 +176,7 @@ public class PartitionManagerTest {
         TestUtilities.log("DONE");
     }
 
-    //@Test
+    @Test
     public void partitionBalancingTooManyHostsTest() throws Exception {
         TestUtilities.log("partitionBalancingTooManyHostsTest");
 

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -185,6 +185,11 @@ public class TestBase {
         }
 
         @Override
+        public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
         public CompletableFuture<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint) {
             return CompletableFuture.completedFuture(null);
         }
@@ -221,24 +226,29 @@ public class TestBase {
             return CompletableFuture.completedFuture(null);
         }
 
-		@Override
-		public CompletableFuture<Lease> getLease(String partitionId) {
+        @Override
+        public CompletableFuture<Lease> getLease(String partitionId) {
             return CompletableFuture.completedFuture(null);
-		}
+        }
 
         @Override
         public CompletableFuture<List<Lease>> getAllLeases() {
             return CompletableFuture.completedFuture(null);
         }
 
-		@Override
-		public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo() {
+        @Override
+        public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo() {
             return CompletableFuture.completedFuture(null);
-		}
+        }
 
         @Override
         public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds) {
             return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId) {
+            return null;
         }
 
         @Override

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -180,7 +180,7 @@ public class TestBase {
         }
 
         @Override
-        public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId) {
+        public CompletableFuture<Void> createAllCheckpointsIfNotExists(List<String> partitionIds) {
             return CompletableFuture.completedFuture(null);
         }
 
@@ -221,13 +221,23 @@ public class TestBase {
             return CompletableFuture.completedFuture(null);
         }
 
+		@Override
+		public CompletableFuture<Lease> getLease(String partitionId) {
+            return CompletableFuture.completedFuture(null);
+		}
+
         @Override
         public CompletableFuture<List<Lease>> getAllLeases() {
             return CompletableFuture.completedFuture(null);
         }
 
+		@Override
+		public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo() {
+            return CompletableFuture.completedFuture(null);
+		}
+
         @Override
-        public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId) {
+        public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestBase.java
@@ -185,11 +185,6 @@ public class TestBase {
         }
 
         @Override
-        public CompletableFuture<Checkpoint> createCheckpointIfNotExists(String partitionId) {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
         public CompletableFuture<Void> updateCheckpoint(Lease lease, Checkpoint checkpoint) {
             return CompletableFuture.completedFuture(null);
         }
@@ -201,11 +196,6 @@ public class TestBase {
     }
 
     class BogusLeaseManager implements ILeaseManager {
-        @Override
-        public int getLeaseRenewIntervalInMilliseconds() {
-            return 0;
-        }
-
         @Override
         public int getLeaseDurationInMilliseconds() {
             return 0;
@@ -232,11 +222,6 @@ public class TestBase {
         }
 
         @Override
-        public CompletableFuture<List<Lease>> getAllLeases() {
-            return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
         public CompletableFuture<List<LeaseStateInfo>> getAllLeasesStateInfo() {
             return CompletableFuture.completedFuture(null);
         }
@@ -244,11 +229,6 @@ public class TestBase {
         @Override
         public CompletableFuture<Void> createAllLeasesIfNotExists(List<String> partitionIds) {
             return CompletableFuture.completedFuture(null);
-        }
-
-        @Override
-        public CompletableFuture<Lease> createLeaseIfNotExists(String partitionId) {
-            return null;
         }
 
         @Override


### PR DESCRIPTION
## Description

This work was prompted by InMobi but is applicable in general to premium customers working with large partition counts: the existing lease handling/balancing code worked fine for small counts (16 or 32 partitions) but experienced severe performance issues with large counts (200, in InMobi's case).

The lease scanning/balancing code was broken out into a separate object, PartitionScanner, which can keep state in member variables and thereby make passing state between async stages much more straightforward. Dividing up the stages into multiple methods also allows using recursive calls to add stages as needed at runtime.

At a high level, the optimizations performed fall into a few buckets:
a) make operations more parallel
b) use knowledge of the number of active hosts to make intelligent guesses about the desired number of leases to own, and where to search for unowned leases to avoid contention
c) make better use of the Azure Storage API to get the info needed in fewer calls
d) because we control both the caller and the callee, we removed certain Storage calls during startup which we know will always be redundant -- we must make the calls on ILeaseManager and ICheckpointManager for the benefit of other implementations, but in our Storage-based implementation certain methods can be no-ops that return success immediately

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.