### PR TITLE
Treat session timeouts as transient

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
@@ -156,7 +156,7 @@ public class SessionHandler extends BaseHandler {
                 }
 
                 session.close();
-                onRemoteSessionOpenError.accept(null, new EventHubException(false, "session creation timedout."));
+                onRemoteSessionOpenError.accept(null, new EventHubException(true, "session creation timedout."));
             }
         }
     }


### PR DESCRIPTION
Close: #306 

Session timedout error is thrown when there is no Connection/transport related error and yet Session creation takes longer than 15secs. At this point - there should be no reason for Session creation to fail - as EventHubs service doesn't perform any validation on Session creation (all validations are done at Link level) - so my original idea is to notify this to error in all cases - hence marked it as non-transient.

However, after seeing the client run in many customer environments - new possibilities like - larger transport error timeout configurations , half-broken connections - evolved and I believe - this timeout should be transient - so that client will retry and try to write bytes (for ex: upon retry - Session OPEN command) on the IO and detect those transient failures.