### PR TITLE
fix reactor recovery codepath upon unhandled exceptions thrown from proton fx 

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -4,10 +4,17 @@
  */
 package com.microsoft.azure.eventhubs.impl;
 
-import com.microsoft.azure.eventhubs.*;
+
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
-import org.apache.qpid.proton.engine.*;
+import org.apache.qpid.proton.engine.BaseHandler;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.EndpointState;
+import org.apache.qpid.proton.engine.Handler;
+import org.apache.qpid.proton.engine.HandlerException;
+import org.apache.qpid.proton.engine.Link;
 import org.apache.qpid.proton.reactor.Reactor;
+import org.apache.qpid.proton.engine.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,6 +30,13 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
+import com.microsoft.azure.eventhubs.CommunicationException;
+import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.OperationCancelledException;
+import com.microsoft.azure.eventhubs.RetryPolicy;
+import com.microsoft.azure.eventhubs.TimeoutException;
 
 /**
  * Abstracts all amqp related details and exposes AmqpConnection object
@@ -293,11 +307,16 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                 this.onReactorError(cause);
             }
 
+            // when the instance of the reactor itself faults - Connection and Links will not be cleaned up even after the
+            // below .close() calls (local closes).
+            // But, we still need to change the states of these to Closed - so that subsequent retries - will
+            // treat the links and connection as closed and re-establish them and continue running on new Reactor instance.
             if (currentConnection.getLocalState() != EndpointState.CLOSED && currentConnection.getRemoteState() != EndpointState.CLOSED) {
                 currentConnection.close();
             }
 
-            for (Link link : this.registeredLinks) {
+            final List<Link> registeredLinksCopy = new LinkedList<>(this.registeredLinks);
+            for (final Link link : registeredLinksCopy) {
                 if (link.getLocalState() != EndpointState.CLOSED && link.getRemoteState() != EndpointState.CLOSED) {
                     link.close();
                 }
@@ -486,7 +505,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                 if (TRACE_LOGGER.isWarnEnabled()) {
                     TRACE_LOGGER.warn(String.format(Locale.US, "messagingFactory[%s], hostName[%s], error[%s]",
                             getClientId(), getHostName(), ExceptionUtil.toStackTraceString(handlerException,
-                                    "UnHandled exception while processing events in reactor:")));
+                                    "Unhandled exception while processing events in reactor, report this error.")));
                 }
 
                 final String message = !StringUtil.isNullOrEmpty(cause.getMessage()) ?
@@ -495,14 +514,17 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                                 handlerException.getMessage() :
                                 "Reactor encountered unrecoverable error";
 
-                EventHubException sbException = new EventHubException(
-                        true,
-                        String.format(Locale.US, "%s, %s", message, ExceptionUtil.getTrackingIDAndTimeToLog()),
-                        cause);
+                final EventHubException sbException;
 
                 if (cause instanceof UnresolvedAddressException) {
                     sbException = new CommunicationException(
-                            String.format(Locale.US, "%s. This is usually caused by incorrect hostname or network configuration. Please check to see if namespace information is correct. %s", message, ExceptionUtil.getTrackingIDAndTimeToLog()),
+                            String.format(Locale.US, "%s. This is usually caused by incorrect hostname or network configuration. Check correctness of namespace information. %s",
+                                    message, ExceptionUtil.getTrackingIDAndTimeToLog()),
+                            cause);
+                } else {
+                    sbException = new EventHubException(
+                            true,
+                            String.format(Locale.US, "%s, %s", message, ExceptionUtil.getTrackingIDAndTimeToLog()),
                             cause);
                 }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
@@ -1,0 +1,60 @@
+package com.microsoft.azure.eventhubs.exceptioncontracts;
+
+import com.microsoft.azure.eventhubs.*;
+import com.microsoft.azure.eventhubs.impl.EventHubClientImpl;
+import com.microsoft.azure.eventhubs.impl.MessagingFactory;
+import com.microsoft.azure.eventhubs.lib.ApiTestBase;
+import com.microsoft.azure.eventhubs.lib.TestContext;
+import org.apache.qpid.proton.engine.BaseHandler;
+import org.apache.qpid.proton.reactor.Reactor;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.TimeUnit;
+
+public class ReactorFaultTest extends ApiTestBase {
+    static final String PARTITION_ID = "0";
+    static ConnectionStringBuilder connStr;
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        connStr = TestContext.getConnectionString();
+    }
+
+    @Test()
+    public void VerifyReactorRestartsOnProtonBugs() throws Exception {
+        final EventHubClient eventHubClient = EventHubClient.createSync(connStr.toString(), TestContext.EXECUTOR_SERVICE);
+
+        try {
+            final PartitionReceiver partitionReceiver = eventHubClient.createEpochReceiverSync(
+                    "$default", "0", EventPosition.fromStartOfStream(), System.currentTimeMillis());
+
+            try {
+                final Field factoryField = EventHubClientImpl.class.getDeclaredField("underlyingFactory");
+                factoryField.setAccessible(true);
+                final MessagingFactory underlyingFactory = (MessagingFactory) factoryField.get(eventHubClient);
+
+                final Field reactorField = MessagingFactory.class.getDeclaredField("reactor");
+                reactorField.setAccessible(true);
+                final Reactor reactor = (Reactor) reactorField.get(underlyingFactory);
+
+                org.apache.qpid.proton.engine.Handler handler = reactor.getHandler();
+                handler.add(new BaseHandler() {
+                    @Override
+                    public void handle(org.apache.qpid.proton.engine.Event e) {
+                        throw new NullPointerException();
+                    }
+                });
+
+                final Iterable<EventData> events = partitionReceiver.receiveSync(100);
+                Assert.assertTrue(events != null && events.iterator().hasNext());
+            } finally {
+                partitionReceiver.closeSync();
+            }
+        } finally {
+            eventHubClient.closeSync();
+        }
+    }
+}


### PR DESCRIPTION
Close: #298 

We have a situation where `List<Links> registeredLinks` is being modified while iterating thru it. Fixed it by maintaining a local copy.

cc: @yvgopal, @binzywu - please check if you need to port this to ServiceBus fx.