### PR TITLE
Handle CompletionException and ExecutionException in ManagementRetry

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -13,6 +13,8 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -378,6 +380,8 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
                             lastException = (EventHubException) error;
                         } else if (error instanceof AmqpException) {
                             lastException = ExceptionUtil.toException(((AmqpException) error).getError());
+                        } else if (error instanceof CompletionException || error instanceof ExecutionException) {
+                            lastException = ExceptionUtil.stripOuterException((Exception) error);
                         } else {
                             lastException = (Exception) error;
                         }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
@@ -143,6 +143,19 @@ public final class ExceptionUtil {
         return null;
     }
 
+   static Exception stripOuterException(final Exception exception) {
+        Throwable throwable = exception.getCause();
+        if (throwable instanceof EventHubException) {
+            return (EventHubException) throwable;
+        } else if (throwable instanceof RuntimeException) {
+            return (RuntimeException) throwable;
+        } else if (throwable != null) {
+            return new RuntimeException(throwable);
+        } else {
+            return new RuntimeException(exception);
+        }
+    }
+
     private static void handle(final Exception exception) throws EventHubException {
         if (exception instanceof InterruptedException) {
             // Re-assert the thread's interrupted status


### PR DESCRIPTION
This PR handles `CompletionException`s and `ExecutionException`s explicitly in `ManagementRetry`. Now, the outer exception is stripped and we will complete exceptionally with the inner exception. 

---

This is to handle the follow two cases: 

**1)**
`java.util.concurrent.CompletionException: com.microsoft.azure.eventhubs.EventHubException: Put token failed. status-code: 500, status-description: The operation did not complete within the allotted timeout of 00:01:00. The time allotted to this operation may have been a portion of a longer timeout. For more information on exception types and proper exception handling, please refer to http://go.microsoft.com/fwlink/?LinkId=761101`

**2)**
`java.util.concurrent.ExecutionException: com.microsoft.azure.eventhubs.EventHubException: Put token failed. status-code: 500, status-description: The service was unable to process the request; please retry the operation. For more information on exception types and proper exception handling, please refer to http://go.microsoft.com/fwlink/?LinkId=761101`

---

As we can see [here](https://github.com/Azure/azure-event-hubs-java/blob/dev/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java#L64), a transient `EventHubException` is thrown when this request response is received. However, because it's wrapped in a `CompletionException`, the client never retries this failure. 


