### PR TITLE
Websockets support

### DIFF
--- a/azure-eventhubs-eph/pom.xml
+++ b/azure-eventhubs-eph/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <version>2.0.1</version>

--- a/azure-eventhubs-extensions/pom.xml
+++ b/azure-eventhubs-extensions/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/azure-eventhubs/pom.xml
+++ b/azure-eventhubs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.0.2</version>
+        <version>1.1.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -47,6 +47,7 @@ import java.util.regex.Pattern;
  * </ul>
  */
 public final class ConnectionStringBuilder {
+
     final static String endpointFormat = "sb://%s.%s";
     final static String hostnameFormat = "sb://%s";
     final static String defaultDomainName = "servicebus.windows.net";
@@ -60,10 +61,11 @@ public final class ConnectionStringBuilder {
     final static String SharedAccessKeyNameConfigName = "SharedAccessKeyName";  // We use a (KeyName, Key) pair OR the SAS token - never both.
     final static String SharedAccessKeyConfigName = "SharedAccessKey";
     final static String SharedAccessSignatureConfigName = "SharedAccessSignature";
+    final static String TransportTypeConfigName = "TransportType";
 
     private static final String AllKeyEnumerateRegex = "(" + HostnameConfigName + "|" + EndpointConfigName + "|" + SharedAccessKeyNameConfigName
             + "|" + SharedAccessKeyConfigName + "|" + SharedAccessSignatureConfigName + "|" + EntityPathConfigName + "|" + OperationTimeoutConfigName
-            + "|" + ")";
+            + "|" + TransportTypeConfigName + ")";
 
     private static final String KeysWithDelimitersRegex = KeyValuePairDelimiter + AllKeyEnumerateRegex
             + KeyValueSeparator;
@@ -74,6 +76,7 @@ public final class ConnectionStringBuilder {
     private String sharedAccessKey;
     private String sharedAccessSignature;
     private Duration operationTimeout;
+    private TransportType transportType;
 
     /**
      * Creates an empty {@link ConnectionStringBuilder}. At minimum, a namespace name, an entity path, SAS key name, and SAS key
@@ -256,6 +259,15 @@ public final class ConnectionStringBuilder {
         return this;
     }
 
+    public TransportType getTransportType() {
+        return (this.transportType == null ? TransportType.Amqp : transportType);
+    }
+
+    public ConnectionStringBuilder setTransportType(final TransportType transportType) {
+        this.transportType = transportType;
+        return this;
+    }
+
     /**
      * Returns an inter-operable connection string that can be used to connect to EventHubs instances.
      *
@@ -292,6 +304,11 @@ public final class ConnectionStringBuilder {
         if (this.operationTimeout != null) {
             connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", OperationTimeoutConfigName,
                     KeyValueSeparator, this.operationTimeout.toString(), KeyValuePairDelimiter));
+        }
+
+        if (this.transportType != null) {
+            connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", TransportTypeConfigName,
+                    KeyValueSeparator, this.transportType.toString(), KeyValuePairDelimiter));
         }
 
         connectionStringBuilder.deleteCharAt(connectionStringBuilder.length() - 1);
@@ -372,6 +389,14 @@ public final class ConnectionStringBuilder {
                     this.operationTimeout = Duration.parse(values[valueIndex]);
                 } catch (DateTimeParseException exception) {
                     throw new IllegalConnectionStringFormatException("Invalid value specified for property 'Duration' in the ConnectionString.", exception);
+                }
+            } else if (key.equalsIgnoreCase(TransportTypeConfigName)) {
+                try {
+                    this.transportType = TransportType.valueOf(values[valueIndex]);
+                } catch (IllegalArgumentException exception) {
+                    throw new IllegalConnectionStringFormatException(
+                            String.format("Invalid value specified for property '%s' in the ConnectionString.", TransportTypeConfigName),
+                            exception);
                 }
             } else {
                 throw new IllegalConnectionStringFormatException(

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/TransportType.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/TransportType.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs;
+
+public enum TransportType {
+    Amqp,
+    AmqpWebSockets
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
@@ -10,6 +10,7 @@ import java.time.Duration;
 
 public final class ClientConstants {
     public final static int AMQPS_PORT = 5671;
+    public final static int HTTPS_PORT = 443;
     public final static int MAX_PARTITION_KEY_LENGTH = 128;
     public final static Symbol SERVER_BUSY_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":server-busy");
     public final static Symbol ARGUMENT_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":argument-error");
@@ -37,7 +38,7 @@ public final class ClientConstants {
     public final static String NO_RETRY = "NoRetry";
     public final static String DEFAULT_RETRY = "Default";
     public final static String PRODUCT_NAME = "MSJavaClient";
-    public final static String CURRENT_JAVACLIENT_VERSION = "1.0.2";
+    public final static String CURRENT_JAVACLIENT_VERSION = "1.1.0-SNAPSHOT";
     public static final String PLATFORM_INFO = getPlatformInfo();
     public static final String FRAMEWORK_INFO = getFrameworkInfo();
     public static final String CBS_ADDRESS = "$cbs";

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
@@ -8,6 +8,7 @@ import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.*;
+import org.apache.qpid.proton.engine.impl.TransportInternal;
 import org.apache.qpid.proton.reactor.Handshaker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +18,7 @@ import java.util.Map;
 
 // ServiceBus <-> ProtonReactor interaction handles all
 // amqp_connection/transport related events from reactor
-public final class ConnectionHandler extends BaseHandler {
+public class ConnectionHandler extends BaseHandler {
 
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(ConnectionHandler.class);
 
@@ -65,10 +66,23 @@ public final class ConnectionHandler extends BaseHandler {
         connection.open();
     }
 
+    protected void addTransportLayers(final Event event, final TransportInternal transport) {
+    }
+
+    protected int getPort() {
+        return ClientConstants.AMQPS_PORT;
+    }
+
+    protected int getMaxFrameSize() {
+        return AmqpConstants.MAX_FRAME_SIZE;
+    }
+
     @Override
     public void onConnectionBound(Event event) {
 
         final Transport transport = event.getTransport();
+
+        this.addTransportLayers(event, (TransportInternal) transport);
 
         final SslDomain domain = makeDomain(SslDomain.Mode.CLIENT);
         transport.ssl(domain);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -5,6 +5,7 @@
 package com.microsoft.azure.eventhubs.impl;
 
 
+import com.microsoft.azure.eventhubs.*;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.BaseHandler;
 import org.apache.qpid.proton.engine.Connection;
@@ -30,13 +31,6 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
-
-import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
-import com.microsoft.azure.eventhubs.CommunicationException;
-import com.microsoft.azure.eventhubs.EventHubException;
-import com.microsoft.azure.eventhubs.OperationCancelledException;
-import com.microsoft.azure.eventhubs.RetryPolicy;
-import com.microsoft.azure.eventhubs.TimeoutException;
 
 /**
  * Abstracts all amqp related details and exposes AmqpConnection object
@@ -81,7 +75,10 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         this.retryPolicy = retryPolicy;
         this.registeredLinks = new LinkedList<>();
         this.reactorLock = new Object();
-        this.connectionHandler = new ConnectionHandler(this);
+        this.connectionHandler =
+                        builder.getTransportType() == TransportType.Amqp
+                        ? new ConnectionHandler(this)
+                        : new WebSocketConnectionHandler(this);
         this.cbsChannelCreateLock = new Object();
         this.mgmtChannelCreateLock = new Object();
         this.tokenProvider = builder.getSharedAccessSignature() == null
@@ -170,13 +167,13 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                 super.onReactorInit(e);
 
                 final Reactor r = e.getReactor();
-                connection = r.connectionToHost(hostName, ClientConstants.AMQPS_PORT, connectionHandler);
+                connection = r.connectionToHost(hostName, connectionHandler.getPort(), connectionHandler);
             }
         });
     }
 
     private void startReactor(final ReactorHandler reactorHandler) throws IOException {
-        final Reactor newReactor = this.reactorFactory.create(reactorHandler);
+        final Reactor newReactor = this.reactorFactory.create(reactorHandler, this.connectionHandler.getMaxFrameSize());
         synchronized (this.reactorLock) {
             this.reactor = newReactor;
             this.reactorScheduler = new ReactorDispatcher(newReactor);
@@ -215,7 +212,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         }
 
         if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED) {
-            this.connection = this.getReactor().connectionToHost(this.hostName, ClientConstants.AMQPS_PORT, this.connectionHandler);
+            this.connection = this.getReactor().connectionToHost(this.hostName, this.connectionHandler.getPort(), this.connectionHandler);
         }
 
         final Session session = this.connection.session();
@@ -381,8 +378,8 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
 
     public static class ReactorFactory {
 
-        public Reactor create(final ReactorHandler reactorHandler) throws IOException {
-            return ProtonUtil.reactor(reactorHandler);
+        public Reactor create(final ReactorHandler reactorHandler, final int maxFrameSize) throws IOException {
+            return ProtonUtil.reactor(reactorHandler, maxFrameSize);
         }
     }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProtonUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProtonUtil.java
@@ -15,10 +15,10 @@ public final class ProtonUtil {
     private ProtonUtil() {
     }
 
-    public static Reactor reactor(ReactorHandler reactorHandler) throws IOException {
+    public static Reactor reactor(final ReactorHandler reactorHandler, final int maxFrameSize) throws IOException {
 
         final ReactorOptions reactorOptions = new ReactorOptions();
-        reactorOptions.setMaxFrameSize(AmqpConstants.MAX_FRAME_SIZE);
+        reactorOptions.setMaxFrameSize(maxFrameSize);
         reactorOptions.setEnableSaslByDefault(true);
 
         final Reactor reactor = Proton.reactor(reactorOptions, reactorHandler);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
@@ -1,0 +1,36 @@
+package com.microsoft.azure.eventhubs.impl;
+
+import com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl;
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.impl.TransportInternal;
+
+public class WebSocketConnectionHandler extends ConnectionHandler {
+    public WebSocketConnectionHandler(AmqpConnection messagingFactory) {
+        super(messagingFactory);
+    }
+
+    @Override
+    protected void addTransportLayers(final Event event, final TransportInternal transport) {
+        final WebSocketImpl webSocket = new WebSocketImpl();
+        webSocket.configure(
+                event.getConnection().getHostname(),
+                "/$servicebus/websocket",
+                null,
+                0,
+                "AMQPWSB10",
+                null,
+                null);
+
+        transport.addTransportLayer(webSocket);
+    }
+
+    @Override
+    protected int getPort() {
+        return ClientConstants.HTTPS_PORT;
+    }
+
+    @Override
+    protected int getMaxFrameSize() {
+        return 4 * 1024;
+    }
+}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
@@ -6,6 +6,7 @@ package com.microsoft.azure.eventhubs.connstrbuilder;
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.IllegalConnectionStringFormatException;
+import com.microsoft.azure.eventhubs.TransportType;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,7 +15,7 @@ import java.time.Duration;
 import java.util.function.Consumer;
 
 public class ConnStrBuilderTest extends ApiTestBase {
-    static final String correctConnectionString = "Endpoint=sb://endpoint1;EntityPath=eventhub1;SharedAccessKeyName=somevalue;SharedAccessKey=something;OperationTimeout=PT5S";
+    static final String correctConnectionString = "Endpoint=sb://endpoint1;EntityPath=eventhub1;SharedAccessKeyName=somevalue;SharedAccessKey=something;OperationTimeout=PT5S;TransportType=Amqp";
     static final Consumer<ConnectionStringBuilder> validateConnStrBuilder = new Consumer<ConnectionStringBuilder>() {
         @Override
         public void accept(ConnectionStringBuilder connStrBuilder) {
@@ -22,6 +23,7 @@ public class ConnStrBuilderTest extends ApiTestBase {
             Assert.assertTrue(connStrBuilder.getEndpoint().getHost().equals("endpoint1"));
             Assert.assertTrue(connStrBuilder.getSasKey().equals("something"));
             Assert.assertTrue(connStrBuilder.getSasKeyName().equals("somevalue"));
+            Assert.assertTrue(connStrBuilder.getTransportType() == TransportType.Amqp);
             Assert.assertTrue(connStrBuilder.getOperationTimeout().equals(Duration.ofSeconds(5)));
         }
     };
@@ -34,6 +36,14 @@ public class ConnStrBuilderTest extends ApiTestBase {
     @Test(expected = IllegalConnectionStringFormatException.class)
     public void throwOnUnrecognizedParts() {
         new ConnectionStringBuilder(correctConnectionString + ";" + "something");
+    }
+
+    @Test(expected = IllegalConnectionStringFormatException.class)
+    public void throwOnInvalidTransportType() {
+        ConnectionStringBuilder connectionStringBuilder = new ConnectionStringBuilder(correctConnectionString);
+        String connectionStringWithTransportType = connectionStringBuilder.setTransportType(TransportType.AmqpWebSockets).toString();
+        String connectionStringWithInvalidTransportType = connectionStringWithTransportType.replace(TransportType.AmqpWebSockets.toString(), "invalid");
+        new ConnectionStringBuilder(connectionStringWithInvalidTransportType);
     }
 
     @Test
@@ -49,8 +59,9 @@ public class ConnStrBuilderTest extends ApiTestBase {
                 .setEndpoint(connStrBuilder.getEndpoint())
                 .setEventHubName(connStrBuilder.getEventHubName())
                 .setSasKeyName(connStrBuilder.getSasKeyName())
-                .setSasKey(connStrBuilder.getSasKey());
-        secondConnStr.setOperationTimeout(connStrBuilder.getOperationTimeout());
+                .setSasKey(connStrBuilder.getSasKey())
+                .setTransportType(connStrBuilder.getTransportType())
+                .setOperationTimeout(connStrBuilder.getOperationTimeout());
 
         validateConnStrBuilder.accept(new ConnectionStringBuilder(secondConnStr.toString()));
     }
@@ -62,8 +73,10 @@ public class ConnStrBuilderTest extends ApiTestBase {
         validateConnStrBuilder.accept(testConnStrBuilder);
 
         connStrBuilder.setOperationTimeout(Duration.ofSeconds(8));
+        connStrBuilder.setTransportType(TransportType.AmqpWebSockets);
 
         ConnectionStringBuilder testConnStrBuilder1 = new ConnectionStringBuilder(connStrBuilder.toString());
         Assert.assertTrue(testConnStrBuilder1.getOperationTimeout().getSeconds() == 8);
+        Assert.assertTrue(testConnStrBuilder1.getTransportType() == TransportType.AmqpWebSockets);
     }
 }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
@@ -17,7 +17,6 @@ import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 
 public class SendLargeMessageTest extends ApiTestBase {
-    static ConnectionStringBuilder connStr;
     static String partitionId = "0";
 
     static EventHubClient ehClient;
@@ -27,8 +26,11 @@ public class SendLargeMessageTest extends ApiTestBase {
     static PartitionReceiver receiver;
 
     @BeforeClass
-    public static void initializeEventHub() throws Exception {
-        connStr = TestContext.getConnectionString();
+    public static void initialize() throws Exception {
+        initializeEventHubClients(TestContext.getConnectionString());
+    }
+
+    public static void initializeEventHubClients(ConnectionStringBuilder connStr) throws Exception {
 
         ehClient = EventHubClient.create(connStr.toString(), TestContext.EXECUTOR_SERVICE).get();
         sender = ehClient.createPartitionSender(partitionId).get();

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/WebSocketsSendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/WebSocketsSendLargeMessageTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs.exceptioncontracts;
+
+import com.microsoft.azure.eventhubs.*;
+import com.microsoft.azure.eventhubs.lib.ApiTestBase;
+import com.microsoft.azure.eventhubs.lib.TestContext;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+public class WebSocketsSendLargeMessageTest extends ApiTestBase {
+    private static SendLargeMessageTest sendLargeMessageTest;
+
+    @BeforeClass
+    public static void initialize() throws Exception {
+        final ConnectionStringBuilder connectionStringBuilder = TestContext.getConnectionString();
+        connectionStringBuilder.setTransportType(TransportType.AmqpWebSockets);
+        sendLargeMessageTest = new SendLargeMessageTest();
+        SendLargeMessageTest.initializeEventHubClients(connectionStringBuilder);
+    }
+
+    @AfterClass()
+    public static void cleanup() throws EventHubException {
+        SendLargeMessageTest.cleanup();
+    }
+
+    @Test()
+    public void sendMsgLargerThan64k() throws EventHubException, InterruptedException, ExecutionException, IOException {
+        sendLargeMessageTest.sendMsgLargerThan64k();
+    }
+
+    @Test(expected = PayloadSizeExceededException.class)
+    public void sendMsgLargerThan256K() throws EventHubException, InterruptedException, ExecutionException, IOException {
+        sendLargeMessageTest.sendMsgLargerThan256K();
+    }
+
+    @Test()
+    public void sendMsgLargerThan128k() throws EventHubException, InterruptedException, ExecutionException, IOException {
+        sendLargeMessageTest.sendMsgLargerThan128k();
+    }
+}

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/FaultInjectingReactorFactory.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/FaultInjectingReactorFactory.java
@@ -21,7 +21,7 @@ public class FaultInjectingReactorFactory extends MessagingFactory.ReactorFactor
     }
 
     @Override
-    public Reactor create(final ReactorHandler reactorHandler) throws IOException {
+    public Reactor create(final ReactorHandler reactorHandler, final int maxFrameSize) throws IOException {
         final Reactor reactor = Proton.reactor(reactorHandler);
 
         switch (this.faultType) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceiveTest.java
@@ -27,8 +27,12 @@ public class ReceiveTest extends ApiTestBase {
     PartitionReceiver datetimeReceiver = null;
 
     @BeforeClass
-    public static void initializeEventHub() throws Exception {
+    public static void initialize() throws Exception {
         final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+        initializeEventHub(connectionString);
+    }
+
+    public static void initializeEventHub(ConnectionStringBuilder connectionString) throws Exception {
         ehClient = EventHubClient.createSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
         TestBase.pushEventsToPartition(ehClient, partitionId, 25).get();
     }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -194,6 +194,10 @@ public class RequestResponseTest extends ApiTestBase {
 
     @Test
     public void testGetRuntimes() throws Exception {
+        testGetRuntimeInfos(TestContext.getConnectionString());
+    }
+
+    public void testGetRuntimeInfos(ConnectionStringBuilder connectionString) throws Exception {
         EventHubClient ehc = EventHubClient.createSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
         EventHubRuntimeInformation ehInfo = ehc.getRuntimeInformation().get();
 
@@ -237,6 +241,13 @@ public class RequestResponseTest extends ApiTestBase {
         }
 
         ehc.closeSync();
+    }
+
+    @Test
+    public void testGetRuntimesWebSockets() throws Exception {
+        ConnectionStringBuilder connectionStringBuilder = TestContext.getConnectionString();
+        connectionStringBuilder.setTransportType(TransportType.AmqpWebSockets);
+        testGetRuntimeInfos(connectionStringBuilder);
     }
 
     @Test

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SendTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SendTest.java
@@ -33,8 +33,11 @@ public class SendTest extends ApiTestBase {
     List<PartitionReceiver> receivers = new LinkedList<>();
 
     @BeforeClass
-    public static void initializeEventHub() throws Exception {
+    public static void initialize() throws Exception {
         final ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+        initializeEventHub(connectionString);
+    }
+    public static void initializeEventHub(final ConnectionStringBuilder connectionString) throws Exception {
         ehClient = EventHubClient.createSync(connectionString.toString(), TestContext.EXECUTOR_SERVICE);
     }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/WebSocketsReceiveTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/WebSocketsReceiveTest.java
@@ -4,12 +4,14 @@
  */
 package com.microsoft.azure.eventhubs.sendrecv;
 
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.TransportType;
 import com.microsoft.azure.eventhubs.lib.SasTokenTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
 import org.junit.*;
 
-public class SasTokenReceiveTest extends SasTokenTestBase {
+public class WebSocketsReceiveTest extends SasTokenTestBase {
 
     private static ReceiveTest receiveTest;
 
@@ -21,7 +23,9 @@ public class SasTokenReceiveTest extends SasTokenTestBase {
                 && TestContext.getConnectionString().getSasKeyName() == null);
 
         receiveTest = new ReceiveTest();
-        ReceiveTest.initializeEventHub(TestContext.getConnectionString());
+        ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+        connectionString.setTransportType(TransportType.AmqpWebSockets);
+        ReceiveTest.initializeEventHub(connectionString);
     }
 
     @AfterClass()

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/WebSocketsSendTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/WebSocketsSendTest.java
@@ -4,7 +4,9 @@
  */
 package com.microsoft.azure.eventhubs.sendrecv;
 
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.TransportType;
 import com.microsoft.azure.eventhubs.lib.SasTokenTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
 import org.junit.*;
@@ -12,7 +14,7 @@ import org.junit.*;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-public class SasTokenSendTest extends SasTokenTestBase {
+public class WebSocketsSendTest extends SasTokenTestBase {
 
     private static SendTest sendTest;
 
@@ -24,7 +26,10 @@ public class SasTokenSendTest extends SasTokenTestBase {
                 && TestContext.getConnectionString().getSasKeyName() == null);
 
         sendTest = new SendTest();
-        SendTest.initializeEventHub(TestContext.getConnectionString());
+
+        ConnectionStringBuilder connectionString = TestContext.getConnectionString();
+        connectionString.setTransportType(TransportType.AmqpWebSockets);
+        SendTest.initializeEventHub(connectionString);
     }
 
     @AfterClass

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,14 @@
 	
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-eventhubs-clients</artifactId>
-	<version>1.0.2</version>
+	<version>1.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	
 	<url>https://github.com/Azure/azure-event-hubs</url>
 	
 	<properties>
-		<proton-j-version>0.25.0</proton-j-version>
+		<proton-j-version>0.28.0</proton-j-version>
+		<qpid-proton-j-extensions-version>1.0.0</qpid-proton-j-extensions-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.8.0-alpha2</slf4j-version>
 	</properties>
@@ -35,22 +36,27 @@
 	</build>
 
 	 <dependencies>
-	 	<dependency>
-	 	    <groupId>org.apache.qpid</groupId>
-	 	    <artifactId>proton-j</artifactId>
-	 	    <version>${proton-j-version}</version>
-	 	</dependency>
-		<dependency>
-			 <groupId>org.slf4j</groupId>
-			 <artifactId>slf4j-api</artifactId>
-			 <version>${slf4j-version}</version>
-		</dependency>
-		<dependency>
-	 	    <groupId>junit</groupId>
-	 	    <artifactId>junit</artifactId>
-	 	    <version>${junit-version}</version>
-	 	    <scope>test</scope>
-		</dependency>
+         <dependency>
+             <groupId>org.apache.qpid</groupId>
+             <artifactId>proton-j</artifactId>
+             <version>${proton-j-version}</version>
+         </dependency>
+         <dependency>
+             <groupId>com.microsoft.azure</groupId>
+             <artifactId>qpid-proton-j-extensions</artifactId>
+             <version>${qpid-proton-j-extensions-version}</version>
+         </dependency>
+         <dependency>
+             <groupId>org.slf4j</groupId>
+             <artifactId>slf4j-api</artifactId>
+             <version>${slf4j-version}</version>
+         </dependency>
+         <dependency>
+             <groupId>junit</groupId>
+             <artifactId>junit</artifactId>
+             <version>${junit-version}</version>
+             <scope>test</scope>
+         </dependency>
 	 </dependencies>
 	
 	 <modules> 


### PR DESCRIPTION
1. Supports max_frame_size of 4k (current limitation of `<a href="https://github.com/Azure/qpid-proton-j-extensions">qpid-proton-j-extensions</>` library)
2. doesn't support PROXY on websockets - this will follow.

WebSockets feature is particularly used when enterprise firewall policies doesn't allow traffic on the default Amqp secure port (`5671`).
To send or receive over websockets - which uses port `443`, set the `TransportType` on `ConnectionStringBuilder`, like this:

```
connectionStringBuilder.setTransportType(TransportType.AmqpWebSockets)
```

related: #264 