### PR TITLE
RequestResponseChannel should not throw OperationCancelled on PendingRequests while closing

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseChannel.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/RequestResponseChannel.java
@@ -4,7 +4,7 @@
  */
 package com.microsoft.azure.eventhubs.impl;
 
-import com.microsoft.azure.eventhubs.OperationCancelledException;
+import com.microsoft.azure.eventhubs.EventHubException;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.UnsignedLong;
 import org.apache.qpid.proton.amqp.messaging.Source;
@@ -241,8 +241,10 @@ public class RequestResponseChannel implements IOObject {
         public void onClose(ErrorCondition condition) {
 
             if (condition == null || condition.getCondition() == null) {
-                this.cancelPendingRequests(new OperationCancelledException(
-                        "Operation cancelled as the underlying request-response link closed"));
+                this.cancelPendingRequests(
+                        new EventHubException(
+                                ClientConstants.DEFAULT_IS_TRANSIENT,
+                                "The underlying request-response channel closed, recreate the channel and retry the request."));
 
                 if (onClose != null)
                     onLinkCloseComplete(null);


### PR DESCRIPTION
`OperationCancelledException` should be used when - a `ClientEntity` is closed and the corresponding `pendingRequests` are being cancelled. In this case, an AMQP object is closed and hence, pending requests should be cancelled such that the layers above it can retry.

Close: #366 

CC: @sabeegrewal
