### PR TITLE
WebSockets Proxy support

### DIFF
--- a/ConsumingEvents.md
+++ b/ConsumingEvents.md
@@ -26,7 +26,7 @@ following dependency declaration inside of your Maven project file:
     <dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs</artifactId>
-   		<version>1.1.0</version>
+   		<version>1.2.0</version>
     </dependency>
 ```
  
@@ -199,7 +199,7 @@ an outdated offset.
 Azure Event Hubs requires using the AMQP 1.0 protocol for consuming events. 
 
 AMQP 1.0 is a TCP based protocol. For Azure Event Hubs, all traffic *must* be protected using TLS (SSL) and is using 
-TCP port 5672. For the WebSocket binding of AMQP, traffic flows via port 443.  
+TCP port 5671. For the WebSocket binding of AMQP, traffic flows via port 443.  
 
 ## Connection Strings
 

--- a/PublishingEvents.md
+++ b/PublishingEvents.md
@@ -12,7 +12,7 @@ following dependency declaration inside of your Maven project file:
     <dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs</artifactId>
-   		<version>1.1.0</version>
+   		<version>1.2.0</version>
    	</dependency>
  ```
  

--- a/azure-eventhubs-eph/pom.xml
+++ b/azure-eventhubs-eph/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <version>2.0.1</version>

--- a/azure-eventhubs-extensions/pom.xml
+++ b/azure-eventhubs-extensions/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/azure-eventhubs/pom.xml
+++ b/azure-eventhubs/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>azure-eventhubs-clients</artifactId>
-        <version>1.1.0</version>
+        <version>1.2.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -85,6 +85,46 @@ public interface EventHubClient {
     }
 
     /**
+     * Sets hostname to be used while connecting to proxy.
+     * ProxyHostName is valid only while using AmqpWebSockets as TransportType.
+     * @param hostName hostname to be used while connecting to proxy
+     */
+    static void setProxyHostName(final String hostName) {
+        EventHubClientImpl.setProxyHostName(hostName);
+    }
+
+    /**
+     * Sets port to be used while connecting to proxy.
+     * ProxyHostPort is valid only while using AmqpWebSockets as TransportType.
+     * @param port port to be used while connecting to proxy
+     */
+    static void setProxyHostPort(final int port) {
+        EventHubClientImpl.setProxyHostPort(port);
+    }
+
+    /**
+     * Sets userName to be used while connecting to proxy.
+     * ProxyUserName is valid only while using AmqpWebSockets as TransportType.
+     * Library implements Basic Authorization as specified in Basic HTTP Authentication Scheme
+     * RFC: https://tools.ietf.org/html/rfc7617.
+     * @param userName userName to be used while connecting to proxy
+     */
+    static void setProxyUserName(final String userName) {
+        EventHubClientImpl.setProxyUserName(userName);
+    }
+
+    /**
+     * Sets password to be used while connecting to proxy.
+     * ProxyPassword is valid only while using AmqpWebSockets as TransportType.
+     * Library implements Basic Authorization as specified in Basic HTTP Authentication Scheme
+     * RFC: https://tools.ietf.org/html/rfc7617.
+     * @param password
+     */
+    static void setProxyPassword(final String password) {
+        EventHubClientImpl.setProxyPassword(password);
+    }
+
+    /**
      * @return the name of the Event Hub this client is connected to.
      */
     String getEventHubName();

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
@@ -9,6 +9,10 @@ import org.apache.qpid.proton.engine.Link;
 
 public interface AmqpConnection {
 
+    /**
+     * Host name intended to be used on Amqp Connection Open frame
+     * @return host name
+     */
     String getHostName();
 
     void onOpenComplete(Exception exception);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
@@ -8,6 +8,9 @@ import org.apache.qpid.proton.amqp.transport.ErrorCondition;
 import org.apache.qpid.proton.engine.Link;
 
 public interface AmqpConnection {
+
+    String getHostName();
+
     void onOpenComplete(Exception exception);
 
     void onConnectionError(ErrorCondition error);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
@@ -38,7 +38,7 @@ public final class ClientConstants {
     public final static String NO_RETRY = "NoRetry";
     public final static String DEFAULT_RETRY = "Default";
     public final static String PRODUCT_NAME = "MSJavaClient";
-    public final static String CURRENT_JAVACLIENT_VERSION = "1.1.0";
+    public final static String CURRENT_JAVACLIENT_VERSION = "1.2.0";
     public static final String PLATFORM_INFO = getPlatformInfo();
     public static final String FRAMEWORK_INFO = getFrameworkInfo();
     public static final String CBS_ADDRESS = "$cbs";

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
@@ -4,6 +4,7 @@
  */
 package com.microsoft.azure.eventhubs.impl;
 
+import com.microsoft.azure.eventhubs.TransportType;
 import org.apache.qpid.proton.Proton;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.transport.ErrorCondition;
@@ -29,10 +30,24 @@ public class ConnectionHandler extends BaseHandler {
 
     private final AmqpConnection messagingFactory;
 
-    public ConnectionHandler(final AmqpConnection messagingFactory) {
+    protected ConnectionHandler(final AmqpConnection messagingFactory) {
 
         add(new Handshaker());
         this.messagingFactory = messagingFactory;
+    }
+
+    static ConnectionHandler create(TransportType transportType, AmqpConnection messagingFactory) {
+        switch (transportType) {
+            case AMQP_WEB_SOCKETS:
+                if (ProxyConnectionHandler.shouldUseProxy()) {
+                    return new ProxyConnectionHandler(messagingFactory);
+                } else {
+                    return new WebSocketConnectionHandler(messagingFactory);
+                }
+            case AMQP:
+            default:
+                return new ConnectionHandler(messagingFactory);
+        }
     }
 
     private static SslDomain makeDomain(SslDomain.Mode mode) {
@@ -51,7 +66,7 @@ public class ConnectionHandler extends BaseHandler {
         final Connection connection = event.getConnection();
         final String hostName = new StringBuilder(this.messagingFactory.getHostName())
                                     .append(":")
-                                    .append(String.valueOf(this.getPort()))
+                                    .append(String.valueOf(this.getProtocolPort()))
                                         .toString();
 
         connection.setHostname(hostName);
@@ -79,7 +94,29 @@ public class ConnectionHandler extends BaseHandler {
         transport.ssl(domain);
     }
 
-    protected int getPort() {
+    /**
+     * HostName to be used for socket creation.
+     * for ex: in case of proxy server - this could be proxy ip address
+     * @return host name
+     */
+    public String getOutboundSocketHostName() {
+        return messagingFactory.getHostName();
+    }
+
+    /**
+     * port used to create socket.
+     * for ex: in case of talking to event hubs service via proxy - use proxy port
+     * @return port
+     */
+    protected int getOutboundSocketPort() {
+        return this.getProtocolPort();
+    }
+
+    /**
+     * Port used on connection open frame
+     * @return port
+     */
+    protected int getProtocolPort() {
         return ClientConstants.AMQPS_PORT;
     }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
@@ -75,6 +75,8 @@ public class ConnectionHandler extends BaseHandler {
     }
 
     protected void addTransportLayers(final Event event, final TransportInternal transport) {
+        final SslDomain domain = makeDomain(SslDomain.Mode.CLIENT);
+        transport.ssl(domain);
     }
 
     protected int getPort() {
@@ -91,9 +93,6 @@ public class ConnectionHandler extends BaseHandler {
         final Transport transport = event.getTransport();
 
         this.addTransportLayers(event, (TransportInternal) transport);
-
-        final SslDomain domain = makeDomain(SslDomain.Mode.CLIENT);
-        transport.ssl(domain);
     }
 
     @Override

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
@@ -49,7 +49,10 @@ public class ConnectionHandler extends BaseHandler {
     public void onConnectionInit(Event event) {
 
         final Connection connection = event.getConnection();
-        final String hostName = event.getReactor().getConnectionAddress(connection);
+        final String hostName = new StringBuilder(this.messagingFactory.getHostName())
+                                    .append(":")
+                                    .append(String.valueOf(this.getPort()))
+                                        .toString();
 
         connection.setHostname(hostName);
         connection.setContainer(StringUtil.getRandomString());

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -41,6 +41,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
      * It will be truncated to 128 characters
      */
     public static String USER_AGENT = null;
+
     private final String eventHubName;
     private final Object senderCreateSync;
     private volatile boolean isSenderCreateStarted;
@@ -49,6 +50,11 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
     private volatile Timer timer;
 
     private CompletableFuture<Void> createSender;
+
+    volatile static String proxyHostName = null;
+    volatile static int proxyHostPort = 0;
+    volatile static String proxyUserName = null;
+    volatile static String proxyPassword = null;
 
     private EventHubClientImpl(final ConnectionStringBuilder connectionString, final Executor executor) {
         super(StringUtil.getRandomString(), null, executor);
@@ -76,6 +82,22 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
 
     public String getEventHubName() {
         return eventHubName;
+    }
+
+    public static void setProxyHostName(final String hostName) {
+        EventHubClientImpl.proxyHostName = hostName;
+    }
+
+    public static void setProxyHostPort(final int port) {
+        EventHubClientImpl.proxyHostPort = port;
+    }
+
+    public static void setProxyUserName(final String userName) {
+        EventHubClientImpl.proxyUserName = userName;
+    }
+
+    public static void setProxyPassword(final String password) {
+        EventHubClientImpl.proxyPassword = password;
     }
 
     public final EventDataBatch createBatch(BatchOptions options) throws EventHubException {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -146,6 +146,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         return messagingFactory.open;
     }
 
+    @Override
     public String getHostName() {
         return this.hostName;
     }
@@ -174,7 +175,8 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                 super.onReactorInit(e);
 
                 final Reactor r = e.getReactor();
-                connection = r.connectionToHost(hostName, connectionHandler.getPort(), connectionHandler);
+                // connection = r.connectionToHost(hostName, connectionHandler.getPort(), connectionHandler);
+                connection = r.connectionToHost("10.91.40.58", 8888, connectionHandler);
             }
         });
     }
@@ -219,7 +221,8 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         }
 
         if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED) {
-            this.connection = this.getReactor().connectionToHost(this.hostName, this.connectionHandler.getPort(), this.connectionHandler);
+            // this.connection = this.getReactor().connectionToHost(this.hostName, this.connectionHandler.getPort(), this.connectionHandler);
+            this.connection = this.getReactor().connectionToHost("10.91.40.58", 8888, this.connectionHandler);
         }
 
         final Session session = this.connection.session();

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -82,10 +82,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         this.retryPolicy = retryPolicy;
         this.registeredLinks = new LinkedList<>();
         this.reactorLock = new Object();
-        this.connectionHandler =
-                        builder.getTransportType() == TransportType.AMQP
-                        ? new ConnectionHandler(this)
-                        : new WebSocketConnectionHandler(this);
+        this.connectionHandler = ConnectionHandler.create(builder.getTransportType(), this);
         this.cbsChannelCreateLock = new Object();
         this.mgmtChannelCreateLock = new Object();
         this.tokenProvider = builder.getSharedAccessSignature() == null
@@ -175,8 +172,10 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
                 super.onReactorInit(e);
 
                 final Reactor r = e.getReactor();
-                // connection = r.connectionToHost(hostName, connectionHandler.getPort(), connectionHandler);
-                connection = r.connectionToHost("10.91.40.58", 8888, connectionHandler);
+                connection = r.connectionToHost(
+                        connectionHandler.getOutboundSocketHostName(),
+                        connectionHandler.getOutboundSocketPort(),
+                        connectionHandler);
             }
         });
     }
@@ -221,8 +220,10 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         }
 
         if (this.connection == null || this.connection.getLocalState() == EndpointState.CLOSED || this.connection.getRemoteState() == EndpointState.CLOSED) {
-            // this.connection = this.getReactor().connectionToHost(this.hostName, this.connectionHandler.getPort(), this.connectionHandler);
-            this.connection = this.getReactor().connectionToHost("10.91.40.58", 8888, this.connectionHandler);
+            this.connection = this.getReactor().connectionToHost(
+                    this.connectionHandler.getOutboundSocketHostName(),
+                    this.connectionHandler.getOutboundSocketPort(),
+                    this.connectionHandler);
         }
 
         final Session session = this.connection.session();

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProxyConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProxyConnectionHandler.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft. All rights reserved.
+ * Licensed under the MIT license. See LICENSE file in the project root for full license information.
+ */
+package com.microsoft.azure.eventhubs.impl;
+
+import com.microsoft.azure.proton.transport.proxy.ProxyHandler;
+import com.microsoft.azure.proton.transport.proxy.impl.ProxyHandlerImpl;
+import com.microsoft.azure.proton.transport.proxy.impl.ProxyImpl;
+
+import org.apache.qpid.proton.engine.Event;
+import org.apache.qpid.proton.engine.impl.TransportInternal;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ProxyConnectionHandler extends WebSocketConnectionHandler {
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(ProxyConnectionHandler.class);
+
+    public static Boolean shouldUseProxy() {
+        return !StringUtil.isNullOrEmpty(EventHubClientImpl.proxyHostName);
+    }
+
+    public ProxyConnectionHandler(AmqpConnection messagingFactory) {
+        super(messagingFactory);
+    }
+
+    @Override
+    protected void addTransportLayers(final Event event, final TransportInternal transport) {
+        super.addTransportLayers(event, transport);
+
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info("addProxyHandshake: hostname[" + event.getConnection().getHostname() +"]");
+        }
+
+        final ProxyImpl proxy = new ProxyImpl();
+
+        // host name used to create proxy connect request
+        // after creating the socket to proxy
+        final String hostName = event.getConnection().getHostname();
+        final ProxyHandler proxyHandler = new ProxyHandlerImpl();
+        final Map<String, String> proxyHeader = getAuthorizationHeader();
+        proxy.configure(hostName, proxyHeader, proxyHandler, transport);
+
+        transport.addTransportLayer(proxy);
+    }
+
+    @Override
+    public String getOutboundSocketHostName() {
+        return EventHubClientImpl.proxyHostName;
+    }
+
+    @Override
+    public int getOutboundSocketPort() {
+        return EventHubClientImpl.proxyHostPort;
+    }
+
+    private Map<String, String> getAuthorizationHeader() {
+        final String proxyUserName = EventHubClientImpl.proxyUserName;
+        final String proxyPassword = EventHubClientImpl.proxyPassword;
+        if (StringUtil.isNullOrEmpty(proxyUserName)
+                || StringUtil.isNullOrEmpty(proxyPassword)) {
+            return null;
+        }
+
+        final HashMap<String, String> proxyAuthorizationHeader = new HashMap<>();
+        // https://tools.ietf.org/html/rfc7617
+        final String usernamePasswordPair = proxyUserName + ":" + proxyPassword;
+        proxyAuthorizationHeader.put(
+                "Proxy-Authorization",
+                "Basic " + Base64.getEncoder().encodeToString(usernamePasswordPair.getBytes()));
+        return proxyAuthorizationHeader;
+    }
+}

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProxyConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ProxyConnectionHandler.java
@@ -32,10 +32,6 @@ public class ProxyConnectionHandler extends WebSocketConnectionHandler {
     protected void addTransportLayers(final Event event, final TransportInternal transport) {
         super.addTransportLayers(event, transport);
 
-        if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info("addProxyHandshake: hostname[" + event.getConnection().getHostname() +"]");
-        }
-
         final ProxyImpl proxy = new ProxyImpl();
 
         // host name used to create proxy connect request
@@ -46,6 +42,10 @@ public class ProxyConnectionHandler extends WebSocketConnectionHandler {
         proxy.configure(hostName, proxyHeader, proxyHandler, transport);
 
         transport.addTransportLayer(proxy);
+
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info("addProxyHandshake: hostname[" + hostName +"]");
+        }
     }
 
     @Override

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
@@ -34,7 +34,7 @@ public class WebSocketConnectionHandler extends ConnectionHandler {
         transport.addTransportLayer(webSocket);
 
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info("addWebsocketHandshake: hostname[" + event.getConnection().getHostname() +"]");
+            TRACE_LOGGER.info("addWebsocketHandshake: hostname[" + hostName +"]");
         }
 
         super.addTransportLayers(event, transport);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
@@ -23,11 +23,12 @@ public class WebSocketConnectionHandler extends ConnectionHandler {
         webSocket.configure(
                 event.getConnection().getHostname(),
                 "/$servicebus/websocket",
-                null,
+                "",
                 0,
                 "AMQPWSB10",
                 null,
-                null);
+                null,
+                new com.microsoft.azure.proton.transport.ws.impl.ProxyHandlerImpl(null));
 
         transport.addTransportLayer(webSocket);
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/WebSocketConnectionHandler.java
@@ -4,9 +4,6 @@
  */
 package com.microsoft.azure.eventhubs.impl;
 
-import com.microsoft.azure.proton.transport.proxy.Proxy;
-import com.microsoft.azure.proton.transport.proxy.impl.ProxyHandlerImpl;
-import com.microsoft.azure.proton.transport.proxy.impl.ProxyImpl;
 import com.microsoft.azure.proton.transport.ws.impl.WebSocketImpl;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.impl.TransportInternal;
@@ -14,7 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class WebSocketConnectionHandler extends ConnectionHandler {
-    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(ConnectionHandler.class);
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(WebSocketConnectionHandler.class);
 
     public WebSocketConnectionHandler(AmqpConnection messagingFactory) {
         super(messagingFactory);
@@ -41,14 +38,10 @@ public class WebSocketConnectionHandler extends ConnectionHandler {
         }
 
         super.addTransportLayers(event, transport);
-
-        final ProxyImpl proxy = new ProxyImpl();
-        proxy.configure(hostName, null, new ProxyHandlerImpl());
-        transport.addTransportLayer(proxy);
     }
 
     @Override
-    protected int getPort() {
+    protected int getProtocolPort() {
         return ClientConstants.HTTPS_PORT;
     }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
@@ -32,10 +32,10 @@ public class SendLargeMessageTest extends ApiTestBase {
 
     public static void initializeEventHubClients(ConnectionStringBuilder connStr) throws Exception {
 
-        ehClient = EventHubClient.create(connStr.toString(), TestContext.EXECUTOR_SERVICE).get();
+        ehClient = EventHubClient.createSync(connStr.toString(), TestContext.EXECUTOR_SERVICE);
         sender = ehClient.createPartitionSender(partitionId).get();
 
-        receiverHub = EventHubClient.create(connStr.toString(), TestContext.EXECUTOR_SERVICE).get();
+        receiverHub = EventHubClient.createSync(connStr.toString(), TestContext.EXECUTOR_SERVICE);
         receiver = receiverHub.createReceiver(TestContext.getConsumerGroupName(), partitionId, EventPosition.fromEnqueuedTime(Instant.now())).get();
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,14 @@
 	
 	<groupId>com.microsoft.azure</groupId>
 	<artifactId>azure-eventhubs-clients</artifactId>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<packaging>pom</packaging>
 	
 	<url>https://github.com/Azure/azure-event-hubs</url>
 	
 	<properties>
-		<proton-j-version>0.28.1</proton-j-version>
-		<qpid-proton-j-extensions-version>2.0.0-SNAPSHOT</qpid-proton-j-extensions-version>
+		<proton-j-version>0.29.0</proton-j-version>
+		<qpid-proton-j-extensions-version>1.1.0</qpid-proton-j-extensions-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.8.0-alpha2</slf4j-version>
 	</properties>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 	
 	<properties>
 		<proton-j-version>0.28.1</proton-j-version>
-		<qpid-proton-j-extensions-version>1.0.0</qpid-proton-j-extensions-version>
+		<qpid-proton-j-extensions-version>2.0.0-SNAPSHOT</qpid-proton-j-extensions-version>
 	  	<junit-version>4.12</junit-version>
 		<slf4j-version>1.8.0-alpha2</slf4j-version>
 	</properties>

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ the required versions of Apache Qpid Proton-J, and the cryptography library BCPK
    	<dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs</artifactId> 
-   		<version>1.1.0</version>
+   		<version>1.2.0</version>
    	</dependency>
 ```
 


### PR DESCRIPTION
Includes No Authentication & Basic Authentication (https://tools.ietf.org/html/rfc7617) support for proxy.

Depends on qpid-proton-j-extensions library for proxy handshake: https://github.com/Azure/qpid-proton-j-extensions/pull/8 

Close: #264 

CC: @apraovjr @jongio @JamesBirdsall @binzywu @yvgopal @ShubhaVijayasarathy @nemakam @cesarme 

