### PR TITLE
Update version numbers for EPH 2.0.2 release

### DIFF
--- a/azure-eventhubs-eph/pom.xml
+++ b/azure-eventhubs-eph/pom.xml
@@ -7,7 +7,7 @@
         <version>1.2.1</version>
     </parent>
 
-    <version>2.0.1</version>
+    <version>2.0.2</version>
 
     <modelVersion>4.0.0</modelVersion>
 

--- a/readme.md
+++ b/readme.md
@@ -61,7 +61,7 @@ It pulls the required versions of Event Hubs, Azure Storage and GSon libraries.
    	<dependency> 
    		<groupId>com.microsoft.azure</groupId> 
    		<artifactId>azure-eventhubs-eph</artifactId> 
-   		<version>2.0.1</version>
+   		<version>2.0.2</version>
    	</dependency>
 ```  
 


### PR DESCRIPTION
## Description

Update EPH version number to 2.0.2
The only change in this EPH release is updating the client dependency to 1.2.1