### PR TITLE
EPH PartitionPump fixes

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -238,12 +238,15 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
                 // Stage 5: on success, set up the receiver
                 .thenApplyAsync((receiver) ->
                 {
-                    try {
-                        this.partitionReceiver.setPrefetchCount(this.hostContext.getEventProcessorOptions().getPrefetchCount());
-                    } catch (Exception e1) {
-                        TRACE_LOGGER.error(this.hostContext.withHostAndPartition(this.partitionContext, "PartitionReceiver failed setting prefetch count"), e1);
-                        throw new CompletionException(e1);
-                    }
+                	if (this.hostContext.getEventProcessorOptions().getPrefetchCount() > PartitionReceiver.DEFAULT_PREFETCH_COUNT)
+                	{
+	                    try {
+	                        this.partitionReceiver.setPrefetchCount(this.hostContext.getEventProcessorOptions().getPrefetchCount());
+	                    } catch (Exception e1) {
+	                        TRACE_LOGGER.error(this.hostContext.withHostAndPartition(this.partitionContext, "PartitionReceiver failed setting prefetch count"), e1);
+	                        throw new CompletionException(e1);
+	                    }
+                	}
                     this.partitionReceiver.setReceiveTimeout(this.hostContext.getEventProcessorOptions().getReceiveTimeOut());
 
                     TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.partitionContext,

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -23,7 +23,7 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
     final private CompletableFuture<Void> shutdownTriggerFuture;
     final private CompletableFuture<Void> shutdownFinishedFuture;
     private final Object processingSynchronizer;
-    protected CompleteLease lease = null; // protected for testability
+    protected final CompleteLease lease; // protected for testability
     private EventHubClient eventHubClient = null;
     private PartitionReceiver partitionReceiver = null;
     private CloseReason shutdownReason;
@@ -45,13 +45,6 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
                 .thenComposeAsync((empty) -> cleanUpAll(this.shutdownReason), this.hostContext.getExecutor())
                 .thenComposeAsync((empty) -> releaseLeaseOnShutdown(), this.hostContext.getExecutor())
                 .whenCompleteAsync((empty, e) -> { setClosed(); }, this.hostContext.getExecutor());
-    }
-
-    void setLease(CompleteLease newLease) {
-        this.lease = newLease;
-        if (this.partitionContext != null) {
-            this.partitionContext.setLease(newLease);
-        }
     }
 
     // The CompletableFuture returned by startPump remains uncompleted as long as the pump is running.

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PumpManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PumpManager.java
@@ -47,6 +47,7 @@ class PumpManager extends Closable implements Consumer<String> {
         TRACE_LOGGER.info(this.hostContext.withHostAndPartition(lease, "creating new pump"));
         PartitionPump newPartitionPump = createNewPump(lease);
         this.pumpStates.put(lease.getPartitionId(), newPartitionPump);
+        newPartitionPump.startPump();
     }
 
     // Callback used by pumps during pump shutdown. 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PumpManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PumpManager.java
@@ -10,9 +10,10 @@ import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 
-class PumpManager extends Closable {
+class PumpManager extends Closable implements Consumer<String> {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PumpManager.class);
     protected final HostContext hostContext;
     protected ConcurrentHashMap<String, PartitionPump> pumpStates; // protected for testability
@@ -32,27 +33,33 @@ class PumpManager extends Closable {
     	}
     	
         PartitionPump capturedPump = this.pumpStates.get(lease.getPartitionId()); // CONCURRENTHASHTABLE
-        if (capturedPump == null) {
-            // No existing pump, create a new one.
-            TRACE_LOGGER.info(this.hostContext.withHostAndPartition(lease, "creating new pump"));
-            PartitionPump newPartitionPump = createNewPump(lease);
-            this.pumpStates.put(lease.getPartitionId(), newPartitionPump);
-
-            final String capturedPartitionId = lease.getPartitionId();
-            // These are fast, non-blocking actions, so it is OK to run on the same thread that was running pump shutdown.
-            // Also, do not run async because otherwise there can be a race with executor being shut down.
-            newPartitionPump.startPump().whenComplete((r, e) -> this.pumpStates.remove(capturedPartitionId))
-                    .whenComplete((r, e) -> removingPumpTestHook(capturedPartitionId, e));
-        } else {
-            // There already is a pump. Shouldn't get here but do something sane if it happens -- just replace the lease.
-            TRACE_LOGGER.info(this.hostContext.withHostAndPartition(lease, "updating lease for pump"));
-            capturedPump.setLease(lease);
+        if (capturedPump != null) {
+            // There already is a pump. This should never happen and it's not harmless if it does. If we get here,
+        	// it implies that the existing pump is a zombie which is not renewing its lease. 
+            TRACE_LOGGER.error(this.hostContext.withHostAndPartition(lease, "throwing away zombie pump"));
+            // Shutdown should remove the pump from the hashmap, but we don't know what state this pump is in so
+            // remove it manually. ConcurrentHashMap specifies that removing an item that doesn't exist is a safe no-op.
+            this.pumpStates.remove(lease.getPartitionId());
+            // Call shutdown to try to clean up, but do not wait.
+            capturedPump.shutdown(CloseReason.Shutdown);
         }
+
+        TRACE_LOGGER.info(this.hostContext.withHostAndPartition(lease, "creating new pump"));
+        PartitionPump newPartitionPump = createNewPump(lease);
+        this.pumpStates.put(lease.getPartitionId(), newPartitionPump);
     }
+
+    // Callback used by pumps during pump shutdown. 
+	@Override
+	public void accept(String partitionId) {
+		// These are fast, non-blocking actions.
+		this.pumpStates.remove(partitionId);
+		removingPumpTestHook(partitionId);
+	}
 
     // Separated out so that tests can override and substitute their own pump class.
     protected PartitionPump createNewPump(CompleteLease lease) {
-        return new PartitionPump(this.hostContext, lease, this);
+        return new PartitionPump(this.hostContext, lease, this, this);
     }
 
     public CompletableFuture<Void> removePump(String partitionId, final CloseReason reason) {
@@ -82,7 +89,7 @@ class PumpManager extends Closable {
         return CompletableFuture.allOf(futures).whenCompleteAsync((empty, e) -> { setClosed(); }, this.hostContext.getExecutor());
     }
 
-    protected void removingPumpTestHook(String partitionId, Throwable e) {
-        // For test use.
+    protected void removingPumpTestHook(String partitionId) {
+        // For test use. MUST BE FAST, NON-BLOCKING.
     }
 }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.eventhubs.EventData;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
 
 
 class DummyPump extends PumpManager {
@@ -22,11 +23,11 @@ class DummyPump extends PumpManager {
 
     @Override
     protected PartitionPump createNewPump(CompleteLease lease) {
-        return new DummyPartitionPump(this.hostContext, lease, this);
+        return new DummyPartitionPump(this.hostContext, lease, this, this);
     }
 
     @Override
-    protected void removingPumpTestHook(String partitionId, Throwable e) {
+    protected void removingPumpTestHook(String partitionId) {
     	TestBase.logInfo("Steal detected, host " + this.hostContext.getHostName() + " removing " + partitionId);
     }
 
@@ -34,8 +35,8 @@ class DummyPump extends PumpManager {
     private class DummyPartitionPump extends PartitionPump implements Callable<Void> {
         CompletableFuture<Void> blah = null;
 
-        DummyPartitionPump(HostContext hostContext, CompleteLease lease, Closable parent) {
-            super(hostContext, lease, parent);
+        DummyPartitionPump(HostContext hostContext, CompleteLease lease, Closable parent, Consumer<String> pumpManagerCallback) {
+            super(hostContext, lease, parent, pumpManagerCallback);
         }
 
         @Override

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/DummyPump.java
@@ -41,7 +41,6 @@ class DummyPump extends PumpManager {
 
         @Override
         CompletableFuture<Void> startPump() {
-            super.setupPartitionContext();
             this.blah = new CompletableFuture<Void>();
             ((InMemoryLeaseManager) this.hostContext.getLeaseManager()).notifyOnSteal(this.hostContext.getHostName(), this.lease.getPartitionId(), this);
             super.scheduleLeaseRenewer();

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/PrefabEventProcessor.java
@@ -56,7 +56,7 @@ public class PrefabEventProcessor implements IEventProcessor {
                 }
                 */
                 if (this.logEveryEvent) {
-                	TestBase.logInfo("P" + context.getPartitionId() + " " + new String(event.getBytes()) + " @ " + event.getSystemProperties().getOffset());
+                	TestBase.logInfo("(" + context.getOwner() + ") P" + context.getPartitionId() + " " + new String(event.getBytes()) + " @ " + event.getSystemProperties().getOffset());
                 }
                 if (Arrays.equals(event.getBytes(), this.telltaleBytes)) {
                     this.factory.setTelltaleFound(context.getPartitionId());
@@ -75,7 +75,7 @@ public class PrefabEventProcessor implements IEventProcessor {
         }
         this.factory.addBatch(batchSize);
     	if (this.doMarker) {
-            TestBase.logInfo("P" + context.getPartitionId() + " total " + this.eventCount + "(" + (this.eventCount - baseline) + ")");
+            TestBase.logInfo("(" + context.getOwner() + ") P" + context.getPartitionId() + " total " + this.eventCount + "(" + (this.eventCount - baseline) + ")");
     	}
         switch (doCheckpoint) {
             case CKP_NONE:


### PR DESCRIPTION
## Description

This set of fixes is related to customers having trouble with stuck partitions who are seeing "updating lease for pump" message in the log, which happens when PartitionManager is trying to start up a partition but PumpManager already has a pump for it. This implies that the existing pump in the hashtable is a zombie that is no longer updating its lease.

1) Pump shutdown for any cause goes through a unified path that starts with completing PartitionPump.shutdownTriggerFuture, which begins execution of chained tasks. Changed order of the tasks so that first step is removing pump from hashtable in PumpManager via a new callback -- previously it was almost the last thing to happen, meaning the pump might not be removed if an earlier task in the chain hung.

2) If PumpManager finds an existing pump in the hashtable, log an error and remove it, then attempt cleanup but do not wait for cleanup to complete because the state of the pump is suspect. Create a new pump.

3) While testing these fixes, stumbled across an issue apparently caused by setting the prefetch count on a receiver to smaller than the default. EPH uses 300 as the default but the client default is 999. Added logic to set the prefetch only if the user has specified a value greater than the client default.

4) Related test code changes.

