### PR TITLE
Move setPrefetchCount API to the ReceiverOptions class and change the default settings for the prefetch

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -6,8 +6,10 @@
 package com.microsoft.azure.eventprocessorhost;
 
 import com.microsoft.azure.eventhubs.EventPosition;
+import com.microsoft.azure.eventhubs.PartitionReceiver;
 
 import java.time.Duration;
+import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -112,11 +114,21 @@ public final class EventProcessorOptions {
     /***
      * Sets the prefetch count for the underlying event hub client.
      *
-     * The default is 300. This controls how many events are received in advance. 
+     * The default is 500. This controls how many events are received in advance.
      *
      * @param prefetchCount  The new prefetch count.
      */
     public void setPrefetchCount(int prefetchCount) {
+        if (prefetchCount < PartitionReceiver.MINIMUM_PREFETCH_COUNT) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "PrefetchCount has to be above %s", PartitionReceiver.MINIMUM_PREFETCH_COUNT));
+        }
+
+        if (prefetchCount > PartitionReceiver.MAXIMUM_PREFETCH_COUNT) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "PrefetchCount has to be below %s", PartitionReceiver.MAXIMUM_PREFETCH_COUNT));
+        }
+
         this.prefetchCount = prefetchCount;
     }
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -21,10 +21,10 @@ import java.util.function.Consumer;
 class PartitionPump extends Closable implements PartitionReceiveHandler {
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(PartitionPump.class);
     protected final HostContext hostContext;
+    protected final CompleteLease lease; // protected for testability
     final private CompletableFuture<Void> shutdownTriggerFuture;
     final private CompletableFuture<Void> shutdownFinishedFuture;
     private final Object processingSynchronizer;
-    protected final CompleteLease lease; // protected for testability
     private final Consumer<String> pumpManagerCallback;
     private EventHubClient eventHubClient = null;
     private PartitionReceiver partitionReceiver = null;
@@ -35,8 +35,8 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
     private ScheduledFuture<?> leaseRenewerFuture = null;
 
     PartitionPump(HostContext hostContext, CompleteLease lease, Closable parent, Consumer<String> pumpManagerCallback) {
-    	super(parent);
-    	
+        super(parent);
+
         this.hostContext = hostContext;
         this.lease = lease;
         this.pumpManagerCallback = pumpManagerCallback;
@@ -44,14 +44,19 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
 
         this.partitionContext = new PartitionContext(this.hostContext, this.lease.getPartitionId());
         this.partitionContext.setLease(this.lease);
-        
+
         // Set up the shutdown futures. The shutdown process can be triggered just by completing this.shutdownFuture.
         this.shutdownTriggerFuture = new CompletableFuture<Void>();
         this.shutdownFinishedFuture = this.shutdownTriggerFuture
-        		.handleAsync((r, e) -> { this.pumpManagerCallback.accept(this.lease.getPartitionId()); return cancelPendingOperations(); }, this.hostContext.getExecutor())
+                .handleAsync((r, e) -> {
+                    this.pumpManagerCallback.accept(this.lease.getPartitionId());
+                    return cancelPendingOperations();
+                }, this.hostContext.getExecutor())
                 .thenComposeAsync((empty) -> cleanUpAll(this.shutdownReason), this.hostContext.getExecutor())
                 .thenComposeAsync((empty) -> releaseLeaseOnShutdown(), this.hostContext.getExecutor())
-                .whenCompleteAsync((empty, e) -> { setClosed(); }, this.hostContext.getExecutor());
+                .whenCompleteAsync((empty, e) -> {
+                    setClosed();
+                }, this.hostContext.getExecutor());
     }
 
     // The CompletableFuture returned by startPump remains uncompleted as long as the pump is running.
@@ -157,11 +162,11 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
     }
 
     protected void scheduleLeaseRenewer() {
-    	if (!getIsClosingOrClosed()) {
-	        int seconds = this.hostContext.getPartitionManagerOptions().getLeaseRenewIntervalInSeconds();
-	        this.leaseRenewerFuture = this.hostContext.getExecutor().schedule(() -> leaseRenewer(), seconds, TimeUnit.SECONDS);
-	        TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.lease, "scheduling leaseRenewer in " + seconds));
-    	}
+        if (!getIsClosingOrClosed()) {
+            int seconds = this.hostContext.getPartitionManagerOptions().getLeaseRenewIntervalInSeconds();
+            this.leaseRenewerFuture = this.hostContext.getExecutor().schedule(() -> leaseRenewer(), seconds, TimeUnit.SECONDS);
+            TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.lease, "scheduling leaseRenewer in " + seconds));
+        }
     }
 
     private CompletableFuture<Boolean> openClients() {
@@ -198,8 +203,6 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
                 // Stage 3: set up other receiver options, create receiver if initial offset is valid
                 .thenComposeAsync((startAt) ->
                 {
-                    ReceiverOptions options = new ReceiverOptions();
-                    options.setReceiverRuntimeMetricEnabled(this.hostContext.getEventProcessorOptions().getReceiverRuntimeMetricEnabled());
                     long epoch = this.lease.getEpoch();
 
                     TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.partitionContext,
@@ -208,10 +211,15 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
                     CompletableFuture<PartitionReceiver> receiverFuture = null;
 
                     try {
+                        ReceiverOptions options = new ReceiverOptions();
+                        options.setReceiverRuntimeMetricEnabled(this.hostContext.getEventProcessorOptions().getReceiverRuntimeMetricEnabled());
+                        options.setPrefetchCount(this.hostContext.getEventProcessorOptions().getPrefetchCount());
+
                         receiverFuture = this.eventHubClient.createEpochReceiver(this.partitionContext.getConsumerGroupName(),
                                 this.partitionContext.getPartitionId(), startAt, epoch, options);
                         this.internalOperationFuture = receiverFuture;
                     } catch (EventHubException e) {
+                        TRACE_LOGGER.error(this.hostContext.withHostAndPartition(this.partitionContext, "Opening EH receiver failed with an error "), e);
                         receiverFuture = new CompletableFuture<PartitionReceiver>();
                         receiverFuture.completeExceptionally(e);
                     }
@@ -238,15 +246,6 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
                 // Stage 5: on success, set up the receiver
                 .thenApplyAsync((receiver) ->
                 {
-                	if (this.hostContext.getEventProcessorOptions().getPrefetchCount() > PartitionReceiver.DEFAULT_PREFETCH_COUNT)
-                	{
-	                    try {
-	                        this.partitionReceiver.setPrefetchCount(this.hostContext.getEventProcessorOptions().getPrefetchCount());
-	                    } catch (Exception e1) {
-	                        TRACE_LOGGER.error(this.hostContext.withHostAndPartition(this.partitionContext, "PartitionReceiver failed setting prefetch count"), e1);
-	                        throw new CompletionException(e1);
-	                    }
-                	}
                     this.partitionReceiver.setReceiveTimeout(this.hostContext.getEventProcessorOptions().getReceiveTimeOut());
 
                     TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.partitionContext,
@@ -386,8 +385,8 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
     }
 
     protected void internalShutdown(CloseReason reason, Throwable e) {
-    	setClosing();
-    	
+        setClosing();
+
         this.shutdownReason = reason;
         if (e == null) {
             this.shutdownTriggerFuture.complete(null);
@@ -412,7 +411,7 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
             return;
         }
         if (getIsClosingOrClosed()) {
-        	return;
+            return;
         }
 
         // Stage 0: renew the lease

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiveHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiveHandler.java
@@ -14,6 +14,7 @@ public interface PartitionReceiveHandler {
 
     /**
      * Maximum number of {@link EventData} to supply while invoking {@link #onReceive(Iterable)}
+     * <p>Ensure that the value should be less than or equal to the value of {@link ReceiverOptions#getPrefetchCount()}
      *
      * @return value indicating the maximum number of {@link EventData} to supply while invoking {@link #onReceive(Iterable)}
      */

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionReceiver.java
@@ -24,8 +24,9 @@ import java.util.concurrent.CompletableFuture;
  */
 public interface PartitionReceiver {
 
-    int MINIMUM_PREFETCH_COUNT = 10;
-    int DEFAULT_PREFETCH_COUNT = 999;
+    int MINIMUM_PREFETCH_COUNT = 1;
+    int DEFAULT_PREFETCH_COUNT = 500;
+    int MAXIMUM_PREFETCH_COUNT = 2000;
 
     long NULL_EPOCH = 0;
 
@@ -35,23 +36,6 @@ public interface PartitionReceiver {
      * @return The identifier representing the partition from which this receiver is fetching data
      */
     String getPartitionId();
-
-    /**
-     * Get Prefetch Count configured on the Receiver.
-     *
-     * @return the upper limit of events this receiver will actively receive regardless of whether a receive operation is pending.
-     * @see #setPrefetchCount
-     */
-    int getPrefetchCount();
-
-    /**
-     * Set the number of events that can be pre-fetched and cached at the {@link PartitionReceiver}.
-     * <p>By default the value is 300
-     *
-     * @param prefetchCount the number of events to pre-fetch. value must be between 10 and 999. Default is 300.
-     * @throws EventHubException if setting prefetchCount encounters error
-     */
-    void setPrefetchCount(final int prefetchCount) throws EventHubException;
 
     Duration getReceiveTimeout();
 
@@ -81,6 +65,7 @@ public interface PartitionReceiver {
     /**
      * Get the {@link EventPosition} that corresponds to an {@link EventData} which was returned last by the receiver.
      * <p> This value will not be populated, unless the knob {@link ReceiverOptions#setReceiverRuntimeMetricEnabled(boolean)} is set.
+     * Note that EventPosition object is initialized using SequenceNumber and other parameters are not set and get will return null.
      *
      * @return the EventPosition object.
      */

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverOptions.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ReceiverOptions.java
@@ -6,6 +6,8 @@ package com.microsoft.azure.eventhubs;
 
 import com.microsoft.azure.eventhubs.impl.ClientConstants;
 
+import java.util.Locale;
+
 /**
  * Represents various optional behaviors which can be turned on or off during the creation of a {@link PartitionReceiver}.
  */
@@ -13,6 +15,11 @@ public final class ReceiverOptions {
 
     private boolean receiverRuntimeMetricEnabled;
     private String identifier;
+    private int prefetchCount;
+
+    public ReceiverOptions() {
+        this.prefetchCount = PartitionReceiver.DEFAULT_PREFETCH_COUNT;
+    }
 
     private static void validateReceiverIdentifier(final String receiverName) {
 
@@ -37,7 +44,8 @@ public final class ReceiverOptions {
 
     /**
      * Knob to enable/disable runtime metric of the receiver. If this is set to true and is passed to {@link EventHubClient#createReceiver},
-     * after the first {@link PartitionReceiver#receive(int)} call, {@link PartitionReceiver#getRuntimeInformation()} is populated.
+     * after the first {@link PartitionReceiver#receive(int)} call, {@link PartitionReceiver#getRuntimeInformation()} and
+     * {@link PartitionReceiver#getEventPosition()} will be populated.
      * <p>
      * This knob facilitates for an optimization where the Consumer of Event Hub has the end of stream details at the disposal,
      * without making any additional {@link EventHubClient#getPartitionRuntimeInformation(String)} call to Event Hubs service.
@@ -80,5 +88,36 @@ public final class ReceiverOptions {
 
         ReceiverOptions.validateReceiverIdentifier(value);
         this.identifier = value;
+    }
+
+    /**
+     * Get Prefetch Count.
+     *
+     * @return the upper limit of events this receiver will actively receive regardless of whether a receive operation is pending.
+     * @see #setPrefetchCount
+     */
+    public int getPrefetchCount() {
+        return this.prefetchCount;
+    }
+
+    /**
+     * Set the number of events that can be pre-fetched and cached at the {@link PartitionReceiver}.
+     * <p>By default the value is 500
+     *
+     * @param prefetchCount the number of events to pre-fetch. value must be between 1 and 2000.
+     * @throws EventHubException if setting prefetchCount encounters error
+     */
+    public void setPrefetchCount(final int prefetchCount) throws EventHubException {
+        if (prefetchCount < PartitionReceiver.MINIMUM_PREFETCH_COUNT) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "PrefetchCount has to be above %s", PartitionReceiver.MINIMUM_PREFETCH_COUNT));
+        }
+
+        if (prefetchCount > PartitionReceiver.MAXIMUM_PREFETCH_COUNT) {
+            throw new IllegalArgumentException(String.format(Locale.US,
+                    "PrefetchCount has to be below %s", PartitionReceiver.MAXIMUM_PREFETCH_COUNT));
+        }
+
+        this.prefetchCount = prefetchCount;
     }
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
@@ -71,7 +71,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
                                                        final EventPosition eventPosition,
                                                        final long epoch,
                                                        final boolean isEpochReceiver,
-                                                       final ReceiverOptions receiverOptions,
+                                                       ReceiverOptions receiverOptions,
                                                        final Executor executor)
             throws EventHubException {
         if (epoch < NULL_EPOCH) {
@@ -80,6 +80,10 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
 
         if (StringUtil.isNullOrWhiteSpace(consumerGroupName)) {
             throw new IllegalArgumentException("specify valid string for argument - 'consumerGroupName'");
+        }
+
+        if (receiverOptions == null) {
+            receiverOptions = new ReceiverOptions();
         }
 
         final PartitionReceiverImpl receiver = new PartitionReceiverImpl(factory, eventHubName, consumerGroupName, partitionId, (EventPositionImpl) eventPosition, epoch, isEpochReceiver, receiverOptions, executor);
@@ -94,7 +98,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
         return MessageReceiver.create(this.underlyingFactory,
                 StringUtil.getRandomString(),
                 String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId),
-                PartitionReceiverImpl.DEFAULT_PREFETCH_COUNT, this)
+                this.receiverOptions.getPrefetchCount(), this)
                 .thenAcceptAsync(new Consumer<MessageReceiver>() {
                     public void accept(MessageReceiver r) {
                         PartitionReceiverImpl.this.internalReceiver = r;
@@ -108,19 +112,6 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
 
     public final String getPartitionId() {
         return this.partitionId;
-    }
-
-    public final int getPrefetchCount() {
-        return this.internalReceiver.getPrefetchCount();
-    }
-
-    public final void setPrefetchCount(final int prefetchCount) throws EventHubException {
-        if (prefetchCount < PartitionReceiverImpl.MINIMUM_PREFETCH_COUNT) {
-            throw new IllegalArgumentException(String.format(Locale.US,
-                    "PrefetchCount has to be above %s", PartitionReceiverImpl.MINIMUM_PREFETCH_COUNT));
-        }
-
-        this.internalReceiver.setPrefetchCount(prefetchCount);
     }
 
     public final Duration getReceiveTimeout() {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
@@ -75,7 +75,7 @@ public class SessionHandler extends BaseHandler {
     @Override
     public void onSessionRemoteOpen(Event e) {
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info(String.format(Locale.US, "entityName[%s], sessionIncCapacity[%s], sessionOutgoingWindow[%s]",
+            TRACE_LOGGER.info(String.format(Locale.US, "onSessionRemoteOpen entityName[%s], sessionIncCapacity[%s], sessionOutgoingWindow[%s]",
                     this.entityName, e.getSession().getIncomingCapacity(), e.getSession().getOutgoingWindow()));
         }
 
@@ -93,7 +93,7 @@ public class SessionHandler extends BaseHandler {
     @Override
     public void onSessionLocalClose(Event e) {
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info(String.format(Locale.US, "entityName[%s], condition[%s]", this.entityName,
+            TRACE_LOGGER.info(String.format(Locale.US, "onSessionLocalClose entityName[%s], condition[%s]", this.entityName,
                     e.getSession().getCondition() == null ? "none" : e.getSession().getCondition().toString()));
         }
     }
@@ -101,7 +101,7 @@ public class SessionHandler extends BaseHandler {
     @Override
     public void onSessionRemoteClose(Event e) {
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info(String.format(Locale.US, "entityName[%s], condition[%s]", this.entityName,
+            TRACE_LOGGER.info(String.format(Locale.US, "onSessionRemoteClose entityName[%s], condition[%s]", this.entityName,
                     e.getSession().getRemoteCondition() == null ? "none" : e.getSession().getRemoteCondition().toString()));
         }
 
@@ -118,7 +118,7 @@ public class SessionHandler extends BaseHandler {
     @Override
     public void onSessionFinal(Event e) {
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info(String.format(Locale.US, "entityName[%s]", this.entityName));
+            TRACE_LOGGER.info(String.format(Locale.US, "onSessionFinal entityName[%s]", this.entityName));
         }
     }
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
@@ -25,7 +25,7 @@ public class EventDataBatchTest extends ApiTestBase {
         final EventDataBatch batch = ehClient.createBatch();
 
         final EventData within = EventData.create(new byte[1024]);
-        final EventData tooBig = EventData.create(new byte[1024 * 500]);
+        final EventData tooBig = EventData.create(new byte[1024 * 1024 * 2]);
 
         Assert.assertTrue(batch.tryAdd(within));
         batch.tryAdd(tooBig);

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/SendLargeMessageTest.java
@@ -56,8 +56,8 @@ public class SendLargeMessageTest extends ApiTestBase {
     }
 
     @Test(expected = PayloadSizeExceededException.class)
-    public void sendMsgLargerThan256K() throws EventHubException, InterruptedException, ExecutionException, IOException {
-        int msgSize = 256 * 1024;
+    public void sendMsgLargerThan1024K() throws EventHubException, InterruptedException, ExecutionException, IOException {
+        int msgSize = 1024 * 1024 * 2;
         byte[] body = new byte[msgSize];
         for (int i = 0; i < msgSize; i++) {
             body[i] = 1;

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/WebSocketsSendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/WebSocketsSendLargeMessageTest.java
@@ -4,7 +4,10 @@
  */
 package com.microsoft.azure.eventhubs.exceptioncontracts;
 
-import com.microsoft.azure.eventhubs.*;
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
+import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.PayloadSizeExceededException;
+import com.microsoft.azure.eventhubs.TransportType;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
 import org.junit.AfterClass;
@@ -36,8 +39,8 @@ public class WebSocketsSendLargeMessageTest extends ApiTestBase {
     }
 
     @Test(expected = PayloadSizeExceededException.class)
-    public void sendMsgLargerThan256K() throws EventHubException, InterruptedException, ExecutionException, IOException {
-        sendLargeMessageTest.sendMsgLargerThan256K();
+    public void sendMsgLargerThan1024K() throws EventHubException, InterruptedException, ExecutionException, IOException {
+        sendLargeMessageTest.sendMsgLargerThan1024K();
     }
 
     @Test()

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/proxy/ProxySendLargeMessageTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/proxy/ProxySendLargeMessageTest.java
@@ -4,14 +4,17 @@
  */
 package com.microsoft.azure.eventhubs.proxy;
 
-import com.microsoft.azure.eventhubs.*;
+import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
+import com.microsoft.azure.eventhubs.EventHubException;
+import com.microsoft.azure.eventhubs.PayloadSizeExceededException;
+import com.microsoft.azure.eventhubs.TransportType;
 import com.microsoft.azure.eventhubs.exceptioncontracts.SendLargeMessageTest;
 import com.microsoft.azure.eventhubs.lib.ApiTestBase;
 import com.microsoft.azure.eventhubs.lib.TestContext;
-import org.jutils.jproxy.ProxyServer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.jutils.jproxy.ProxyServer;
 
 import java.io.IOException;
 import java.net.*;
@@ -28,7 +31,8 @@ public class ProxySendLargeMessageTest extends ApiTestBase {
     @BeforeClass
     public static void initialize() throws Exception {
         proxyServer = ProxyServer.create("localhost", proxyPort);
-        proxyServer.start(t -> {});
+        proxyServer.start(t -> {
+        });
 
         defaultProxySelector = ProxySelector.getDefault();
         ProxySelector.setDefault(new ProxySelector() {
@@ -69,7 +73,7 @@ public class ProxySendLargeMessageTest extends ApiTestBase {
 
     @Test(expected = PayloadSizeExceededException.class)
     public void sendMsgLargerThan256K() throws EventHubException, InterruptedException, ExecutionException, IOException {
-        sendLargeMessageTest.sendMsgLargerThan256K();
+        sendLargeMessageTest.sendMsgLargerThan1024K();
     }
 
     @Test()

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/EventDataBatchAPITest.java
@@ -20,8 +20,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
@@ -153,7 +153,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
 
             int count = 0;
             while (true) {
-                final EventData eventData = EventData.create(new String(new char[new Random().nextInt(50000)]).replace("\0", "a").getBytes());
+                final EventData eventData = EventData.create(new String(new char[50000]).replace("\0", "a").getBytes());
                 for (int i = 0; i < new Random().nextInt(20); i++)
                     eventData.getProperties().put("somekey" + i, "somevalue");
 
@@ -241,7 +241,7 @@ public class EventDataBatchAPITest extends ApiTestBase {
 
         @Override
         public int getMaxEventCount() {
-            return 999;
+            return PartitionReceiver.DEFAULT_PREFETCH_COUNT;
         }
 
         @Override

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpEventHubTest.java
@@ -69,10 +69,8 @@ public class ReceivePumpEventHubTest extends ApiTestBase {
     @Test(expected = IllegalArgumentException.class)
     public void testInvokeWithInvalidArgs() throws Throwable {
         final CompletableFuture<Void> invokeSignal = new CompletableFuture<Void>();
-        final int prefetchCount = 1000;
         receiver.setReceiveTimeout(Duration.ofSeconds(1));
-        receiver.setPrefetchCount(prefetchCount);
-        receiver.setReceiveHandler(new InvokeOnReceiveEventValidator(invokeSignal, prefetchCount + 1), true);
+        receiver.setReceiveHandler(new InvokeOnReceiveEventValidator(invokeSignal, PartitionReceiver.DEFAULT_PREFETCH_COUNT + 1), true);
         try {
             invokeSignal.get(3, TimeUnit.SECONDS);
         } catch (ExecutionException executionException) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SetPrefetchCountTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/SetPrefetchCountTest.java
@@ -39,8 +39,9 @@ public class SetPrefetchCountTest extends ApiTestBase {
 
     @Test()
     public void testSetPrefetchCountToLargeValue() throws EventHubException {
-        testReceiver = ehClient.createReceiverSync(CONSUMER_GROUP_NAME, PARTITION_ID, EventPosition.fromStartOfStream());
-        testReceiver.setPrefetchCount(100000);
+        ReceiverOptions options = new ReceiverOptions();
+        options.setPrefetchCount(2000);
+        testReceiver = ehClient.createReceiverSync(CONSUMER_GROUP_NAME, PARTITION_ID, EventPosition.fromStartOfStream(), options);
         testReceiver.setReceiveTimeout(Duration.ofSeconds(2));
         int eventsReceived = 0;
         int retryCount = 0;
@@ -58,8 +59,9 @@ public class SetPrefetchCountTest extends ApiTestBase {
 
     @Test()
     public void testSetPrefetchCountToSmallValue() throws EventHubException {
-        testReceiver = ehClient.createReceiverSync(CONSUMER_GROUP_NAME, PARTITION_ID, EventPosition.fromStartOfStream());
-        testReceiver.setPrefetchCount(11);
+        ReceiverOptions options = new ReceiverOptions();
+        options.setPrefetchCount(11);
+        testReceiver = ehClient.createReceiverSync(CONSUMER_GROUP_NAME, PARTITION_ID, EventPosition.fromStartOfStream(), options);
         testReceiver.setReceiveTimeout(Duration.ofSeconds(2));
         int eventsReceived = 0;
         int retryCount = 0;


### PR DESCRIPTION
## Description
This pull request includes two major changes related to Prefetch API.

1) Move setPrefetchCount API to the ReceiverOptions class so that prefetch value specified by a user can be used instead of using default value when communicating to the service during link open and initializing a receiver. This change also addresses the receiver stuck issue caused by setPrefetchAPI in a race condition.

2) Change the default value and set the upper bound of the prefetch count. Note that prefetch count should be greater than or equal to maxEventCount which can be set when either a) calling receive() API or b) implementing the getMaxEventCount API of the SessionReceiverHandler interface.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.