### PR TITLE
Fixes several issues in the reactor related components

### DIFF
--- a/ConsumingEvents.md
+++ b/ConsumingEvents.md
@@ -42,11 +42,11 @@ For a simple event consumer, you'll need to import the *com.microsoft.azure.even
 Event Hubs client library uses qpid proton reactor framework which exposes AMQP connection and message delivery related 
 state transitions as reactive events. In the process,
 the library will need to run many asynchronous tasks while sending and receiving messages to Event Hubs.
-So, `EventHubClient` requires an instance of `Executor`, where all these tasks are run.
+So, `EventHubClient` requires an instance of `ScheduledExecutorService`, where all these tasks are run.
 
 
 ```Java
-    ExecutorService executor = Executors.newCachedThreadPool();
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(8)
 ```
 
 The receiver code creates an *EventHubClient* from a given connecting string

--- a/Overview.md
+++ b/Overview.md
@@ -36,11 +36,11 @@ which is quite simple in a Maven build [as we explain in the guide](PublishingEv
 Event Hubs client library uses qpid proton reactor framework which exposes AMQP connection and message delivery related 
 state transitions as reactive events. In the process,
 the library will need to run many asynchronous tasks while sending and receiving messages to Event Hubs.
-So, `EventHubClient` requires an instance of `Executor`, where all these tasks are run.
+So, `EventHubClient` requires an instance of `ScheduledExecutorService`, where all these tasks are run.
 
 
 ```Java
-    ExecutorService executor = Executors.newCachedThreadPool();
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(8)
 ```
 
 Using an Event Hub connection string, which holds all required connection information, including an authorization key or token, 

--- a/PublishingEvents.md
+++ b/PublishingEvents.md
@@ -34,7 +34,7 @@ So, `EventHubClient` requires an instance of `Executor`, where all these tasks a
 
 
 ```Java
-    ExecutorService executor = Executors.newCachedThreadPool();
+    ScheduledExecutorService executor = Executors.newScheduledThreadPool(8)
 ```
 
 Using an Event Hub connection string, which holds all required connection information including an authorization key or token 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionPump.java
@@ -165,7 +165,7 @@ class PartitionPump extends Closable implements PartitionReceiveHandler {
         if (!getIsClosingOrClosed()) {
             int seconds = this.hostContext.getPartitionManagerOptions().getLeaseRenewIntervalInSeconds();
             this.leaseRenewerFuture = this.hostContext.getExecutor().schedule(() -> leaseRenewer(), seconds, TimeUnit.SECONDS);
-            TRACE_LOGGER.info(this.hostContext.withHostAndPartition(this.lease, "scheduling leaseRenewer in " + seconds));
+            TRACE_LOGGER.debug(this.hostContext.withHostAndPartition(this.lease, "scheduling leaseRenewer in " + seconds));
         }
     }
 

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
@@ -7,35 +7,35 @@ package com.microsoft.azure.eventprocessorhost;
 
 import org.junit.Assume;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 final class TestUtilities {
-    static final ExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
-    
+    static final ScheduledExecutorService EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
+
     static void skipIfAppveyor() {
-    	String appveyor = System.getenv("APPVEYOR"); // Set to "true" by Appveyor
-    	if (appveyor != null) {
-    		TestBase.logInfo("SKIPPING - APPVEYOR DETECTED");
-    	}
-    	Assume.assumeTrue(appveyor == null);
+        String appveyor = System.getenv("APPVEYOR"); // Set to "true" by Appveyor
+        if (appveyor != null) {
+            TestBase.logInfo("SKIPPING - APPVEYOR DETECTED");
+        }
+        Assume.assumeTrue(appveyor == null);
     }
 
     static String getStorageConnectionString() {
-    	TestUtilities.skipIfAppveyor();
-    	
+        TestUtilities.skipIfAppveyor();
+
         String retval = System.getenv("EPHTESTSTORAGE");
 
         // if EPHTESTSTORAGE is not set - we cannot run integration tests
         if (retval == null) {
-        	TestBase.logInfo("SKIPPING - NO STORAGE CONNECTION STRING");
+            TestBase.logInfo("SKIPPING - NO STORAGE CONNECTION STRING");
         }
         Assume.assumeTrue(retval != null);
 
         return ((retval != null) ? retval : "");
     }
-    
+
     static Boolean isRunningOnAzure() {
-    	return (System.getenv("EVENT_HUB_CONNECTION_STRING") != null);
+        return (System.getenv("EVENT_HUB_CONNECTION_STRING") != null);
     }
 }

--- a/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
+++ b/azure-eventhubs-eph/src/test/java/com/microsoft/azure/eventprocessorhost/TestUtilities.java
@@ -7,11 +7,11 @@ package com.microsoft.azure.eventprocessorhost;
 
 import org.junit.Assume;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 final class TestUtilities {
-    static final ScheduledExecutorService EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
+    static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
 
     static void skipIfAppveyor() {
         String appveyor = System.getenv("APPVEYOR"); // Set to "true" by Appveyor

--- a/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
+++ b/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
@@ -11,10 +11,11 @@ import org.apache.logging.log4j.core.appender.AbstractManager;
 
 import java.io.IOException;
 import java.util.LinkedList;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public final class EventHubsManager extends AbstractManager {
-    private static final ScheduledThreadPoolExecutor EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
+    private static final ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
     private final String eventHubConnectionString;
     private EventHubClient eventHubSender;
 

--- a/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
+++ b/azure-eventhubs-extensions/src/main/java/com/microsoft/azure/eventhubs/extensions/appender/EventHubsManager.java
@@ -9,13 +9,12 @@ import com.microsoft.azure.eventhubs.EventHubClient;
 import com.microsoft.azure.eventhubs.EventHubException;
 import org.apache.logging.log4j.core.appender.AbstractManager;
 
-import java.io.*;
-import java.util.*;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.io.IOException;
+import java.util.LinkedList;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public final class EventHubsManager extends AbstractManager {
-    private static final ExecutorService EXECUTOR_SERVICE = Executors.newCachedThreadPool();
+    private static final ScheduledThreadPoolExecutor EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
     private final String eventHubConnectionString;
     private EventHubClient eventHubSender;
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/AuthorizationFailedException.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/AuthorizationFailedException.java
@@ -4,12 +4,12 @@
  */
 package com.microsoft.azure.eventhubs;
 
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Authorization failed exception is thrown when error is encountered during authorizing user's permission to run the intended operations.
  * When encountered this exception user should check whether the token/key provided in the connection string (e.g. one passed to
- * {@link EventHubClient#create(String, Executor)}) is valid, and has correct execution right for the intended operations (e.g.
+ * {@link EventHubClient#create(String, ScheduledExecutorService)}) is valid, and has correct execution right for the intended operations (e.g.
  * Receive call will need Listen claim associated with the key/token).
  *
  * @see <a href="http://go.microsoft.com/fwlink/?LinkId=761101">http://go.microsoft.com/fwlink/?LinkId=761101</a>

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventData.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventData.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * The data structure encapsulating the Event being sent-to and received-from EventHubs.
@@ -48,7 +48,7 @@ public interface EventData extends Serializable {
      *
      * @param data the actual payload of data in bytes to be Sent to EventHubs.
      * @return EventData the created {@link EventData} to send to EventHubs.
-     * @see EventHubClient#create(String, Executor)
+     * @see EventHubClient#create(String, ScheduledExecutorService)
      */
     static EventData create(final byte[] data) {
         return new EventDataImpl(data);
@@ -72,7 +72,7 @@ public interface EventData extends Serializable {
      * @param offset Offset in the byte[] to read from ; inclusive index
      * @param length length of the byte[] to be read, starting from offset
      * @return EventData the created {@link EventData} to send to EventHubs.
-     * @see EventHubClient#create(String, Executor)
+     * @see EventHubClient#create(String, ScheduledExecutorService)
      */
     static EventData create(final byte[] data, final int offset, final int length) {
         return new EventDataImpl(data, offset, length);
@@ -94,7 +94,7 @@ public interface EventData extends Serializable {
      *
      * @param buffer ByteBuffer which references the payload of the Event to be sent to EventHubs
      * @return EventData the created {@link EventData} to send to EventHubs.
-     * @see EventHubClient#create(String, Executor)
+     * @see EventHubClient#create(String, ScheduledExecutorService)
      */
     static EventData create(final ByteBuffer buffer) {
         return new EventDataImpl(buffer);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventHubClient.java
@@ -11,41 +11,42 @@ import java.io.IOException;
 import java.nio.channels.UnresolvedAddressException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Anchor class - all EventHub client operations STARTS here.
  *
- * @see EventHubClient#create(String, Executor)
+ * @see EventHubClient#create(String, ScheduledExecutorService)
  */
 public interface EventHubClient {
 
     String DEFAULT_CONSUMER_GROUP_NAME = "$Default";
 
     /**
-     * Synchronous version of {@link #create(String, Executor)}.
+     * Synchronous version of {@link #create(String, ScheduledExecutorService)}.
      *
      * @param connectionString The connection string to be used. See {@link ConnectionStringBuilder} to construct a connectionString.
-     * @param executor         An {@link Executor} to run all tasks performed by {@link EventHubClient}.
+     * @param executor         An {@link ScheduledExecutorService} to run all tasks performed by {@link EventHubClient}.
      * @return EventHubClient which can be used to create Senders and Receivers to EventHub
      * @throws EventHubException If Service Bus service encountered problems during connection creation.
      * @throws IOException       If the underlying Proton-J layer encounter network errors.
      */
-    static EventHubClient createSync(final String connectionString, final Executor executor)
+    static EventHubClient createSync(final String connectionString, final ScheduledExecutorService executor)
             throws EventHubException, IOException {
         return EventHubClient.createSync(connectionString, null, executor);
     }
 
     /**
-     * Synchronous version of {@link #create(String, Executor)}.
+     * Synchronous version of {@link #create(String, ScheduledExecutorService)}.
      *
      * @param connectionString The connection string to be used. See {@link ConnectionStringBuilder} to construct a connectionString.
      * @param retryPolicy      A custom {@link RetryPolicy} to be used when communicating with EventHub.
-     * @param executor         An {@link Executor} to run all tasks performed by {@link EventHubClient}.
+     * @param executor         An {@link ScheduledExecutorService} to run all tasks performed by {@link EventHubClient}.
      * @return EventHubClient which can be used to create Senders and Receivers to EventHub
      * @throws EventHubException If Service Bus service encountered problems during connection creation.
      * @throws IOException       If the underlying Proton-J layer encounter network errors.
      */
-    static EventHubClient createSync(final String connectionString, final RetryPolicy retryPolicy, final Executor executor)
+    static EventHubClient createSync(final String connectionString, final RetryPolicy retryPolicy, final ScheduledExecutorService executor)
             throws EventHubException, IOException {
         return ExceptionUtil.syncWithIOException(() -> create(connectionString, retryPolicy, executor).get());
     }
@@ -56,12 +57,12 @@ public interface EventHubClient {
      * <p>The {@link EventHubClient} created from this method creates a Sender instance internally, which is used by the {@link #send(EventData)} methods.
      *
      * @param connectionString The connection string to be used. See {@link ConnectionStringBuilder} to construct a connectionString.
-     * @param executor         An {@link Executor} to run all tasks performed by {@link EventHubClient}.
+     * @param executor         An {@link ScheduledExecutorService} to run all tasks performed by {@link EventHubClient}.
      * @return CompletableFuture{@literal <EventHubClient>} which can be used to create Senders and Receivers to EventHub
      * @throws EventHubException If Service Bus service encountered problems during connection creation.
      * @throws IOException       If the underlying Proton-J layer encounter network errors.
      */
-    static CompletableFuture<EventHubClient> create(final String connectionString, final Executor executor)
+    static CompletableFuture<EventHubClient> create(final String connectionString, final ScheduledExecutorService executor)
             throws EventHubException, IOException {
         return EventHubClient.create(connectionString, null, executor);
     }
@@ -73,13 +74,13 @@ public interface EventHubClient {
      *
      * @param connectionString The connection string to be used. See {@link ConnectionStringBuilder} to construct a connectionString.
      * @param retryPolicy      A custom {@link RetryPolicy} to be used when communicating with EventHub.
-     * @param executor         An {@link Executor} to run all tasks performed by {@link EventHubClient}.
+     * @param executor         An {@link ScheduledExecutorService} to run all tasks performed by {@link EventHubClient}.
      * @return CompletableFuture{@literal <EventHubClient>} which can be used to create Senders and Receivers to EventHub
      * @throws EventHubException If Service Bus service encountered problems during connection creation.
      * @throws IOException       If the underlying Proton-J layer encounter network errors.
      */
     static CompletableFuture<EventHubClient> create(
-            final String connectionString, final RetryPolicy retryPolicy, final Executor executor)
+            final String connectionString, final RetryPolicy retryPolicy, final ScheduledExecutorService executor)
             throws EventHubException, IOException {
         return EventHubClientImpl.create(connectionString, retryPolicy, executor);
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/PartitionSender.java
@@ -7,14 +7,14 @@ package com.microsoft.azure.eventhubs;
 import com.microsoft.azure.eventhubs.impl.ExceptionUtil;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * This sender class is a logical representation of sending events to a specific EventHub partition. Do not use this class
  * if you do not care about sending events to specific partitions. Instead, use {@link EventHubClient#send} method.
  *
  * @see EventHubClient#createPartitionSender(String)
- * @see EventHubClient#create(String, Executor)
+ * @see EventHubClient#create(String, ScheduledExecutorService)
  */
 public interface PartitionSender {
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/BaseLinkHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/BaseLinkHandler.java
@@ -25,7 +25,7 @@ public class BaseLinkHandler extends BaseHandler {
     public void onLinkLocalClose(Event event) {
         final Link link = event.getLink();
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info(String.format("linkName[%s]", link.getName()));
+            TRACE_LOGGER.info(String.format("onLinkLocalClose linkName[%s]", link.getName()));
         }
 
         closeSession(link);
@@ -33,18 +33,30 @@ public class BaseLinkHandler extends BaseHandler {
 
     @Override
     public void onLinkRemoteClose(Event event) {
+        final Link link = event.getLink();
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info(String.format("onLinkRemoteClose linkName[%s]", link.getName()));
+        }
+
         handleRemoteLinkClosed(event);
     }
 
     @Override
     public void onLinkRemoteDetach(Event event) {
+        final Link link = event.getLink();
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info(String.format("onLinkRemoteDetach linkName[%s]", link.getName()));
+        }
+
         handleRemoteLinkClosed(event);
     }
 
     public void processOnClose(Link link, ErrorCondition condition) {
         if (TRACE_LOGGER.isInfoEnabled()) {
-            TRACE_LOGGER.info("linkName[" + link.getName() +
-                    (condition != null ? "], ErrorCondition[" + condition.getCondition() + ", " + condition.getDescription() + "]" : "], condition[null]"));
+            TRACE_LOGGER.info(String.format("processOnClose linkName[%s], errorCondition[%s], errorDescription[%s]",
+                    link.getName(),
+                    condition != null ? condition.getCondition() : "n/a",
+                    condition != null ? condition.getDescription() : "n/a"));
         }
 
         this.underlyingEntity.onClose(condition);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
@@ -31,7 +31,6 @@ public final class ClientConstants {
     public final static Duration TOKEN_VALIDITY = Duration.ofMinutes(20);
     public final static int DEFAULT_MAX_RETRY_COUNT = 10;
     public final static boolean DEFAULT_IS_TRANSIENT = true;
-    public final static int SESSION_OPEN_TIMEOUT_IN_MS = 15000;
     public final static int REACTOR_IO_POLL_TIMEOUT = 20;
     public final static int SERVER_BUSY_BASE_SLEEP_TIME_IN_SECS = 4;
     public final static int MGMT_CHANNEL_MIN_RETRY_IN_MILLIS = 5;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientEntity.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientEntity.java
@@ -11,7 +11,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 
 /**
  * Contract for all client entities with Open-Close/Abort state m/c
@@ -21,7 +21,7 @@ import java.util.concurrent.Executor;
 abstract class ClientEntity {
 
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(ClientEntity.class);
-    protected final Executor executor;
+    protected final ScheduledExecutorService executor;
     private final String clientId;
     private final Object syncClose;
     private final ClientEntity parent;
@@ -29,7 +29,7 @@ abstract class ClientEntity {
     private boolean isClosing;
     private boolean isClosed;
 
-    protected ClientEntity(final String clientId, final ClientEntity parent, final Executor executor) {
+    protected ClientEntity(final String clientId, final ClientEntity parent, final ScheduledExecutorService executor) {
         this.clientId = clientId;
         this.parent = parent;
         this.executor = executor;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/CustomIOHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/CustomIOHandler.java
@@ -4,14 +4,24 @@ import org.apache.qpid.proton.engine.Connection;
 import org.apache.qpid.proton.engine.Event;
 import org.apache.qpid.proton.engine.Transport;
 import org.apache.qpid.proton.reactor.impl.IOHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Locale;
 
 public class CustomIOHandler extends IOHandler {
 
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(CustomIOHandler.class);
+
     @Override
     public void onTransportClosed(Event event) {
-
         final Transport transport = event.getTransport();
         final Connection connection = event.getConnection();
+
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info(String.format(Locale.US, "onTransportClosed hostname[%s]",
+                    (connection != null ? connection.getHostname() : "n/a")));
+        }
 
         if (transport != null && connection != null && connection.getTransport() != null) {
             transport.unbind();

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -290,7 +290,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
                             (long) rawData.get(ClientConstants.MANAGEMENT_RESULT_LAST_ENQUEUED_SEQUENCE_NUMBER),
                             (String) rawData.get(ClientConstants.MANAGEMENT_RESULT_LAST_ENQUEUED_OFFSET),
                             ((Date) rawData.get(ClientConstants.MANAGEMENT_RESULT_LAST_ENQUEUED_TIME_UTC)).toInstant(),
-                            (boolean)rawData.get(ClientConstants.MANAGEMENT_RESULT_PARTITION_IS_EMPTY)));
+                            (boolean) rawData.get(ClientConstants.MANAGEMENT_RESULT_PARTITION_IS_EMPTY)));
                     return future2;
                 }
             }, this.executor);
@@ -349,7 +349,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
         public void run() {
             final long timeLeft = this.timeoutTracker.remaining().toMillis();
             final CompletableFuture<Map<String, Object>> intermediateFuture = this.mf.getManagementChannel()
-                    .request(this.mf.getReactorScheduler(),
+                    .request(this.mf.getReactorDispatcher(),
                             this.request,
                             timeLeft > 0 ? timeLeft : 0);
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -38,7 +38,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
     private CompletableFuture<Void> createSender;
 
     private EventHubClientImpl(final ConnectionStringBuilder connectionString, final ScheduledExecutorService executor) {
-        super(StringUtil.getRandomString(), null, executor);
+        super("EventHubClientImpl".concat(StringUtil.getRandomString()), null, executor);
 
         this.eventHubName = connectionString.getEventHubName();
         this.senderCreateSync = new Object();
@@ -220,7 +220,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
         if (!this.isSenderCreateStarted) {
             synchronized (this.senderCreateSync) {
                 if (!this.isSenderCreateStarted) {
-                    this.createSender = MessageSender.create(this.underlyingFactory, StringUtil.getRandomString(), this.eventHubName)
+                    this.createSender = MessageSender.create(this.underlyingFactory, this.getClientId().concat("-InternalSender"), this.eventHubName)
                             .thenAcceptAsync(new Consumer<MessageSender>() {
                                 public void accept(MessageSender a) {
                                     EventHubClientImpl.this.sender = a;

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventHubClientImpl.java
@@ -17,7 +17,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -37,7 +37,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
 
     private CompletableFuture<Void> createSender;
 
-    private EventHubClientImpl(final ConnectionStringBuilder connectionString, final Executor executor) {
+    private EventHubClientImpl(final ConnectionStringBuilder connectionString, final ScheduledExecutorService executor) {
         super(StringUtil.getRandomString(), null, executor);
 
         this.eventHubName = connectionString.getEventHubName();
@@ -45,7 +45,7 @@ public final class EventHubClientImpl extends ClientEntity implements EventHubCl
     }
 
     public static CompletableFuture<EventHubClient> create(
-            final String connectionString, final RetryPolicy retryPolicy, final Executor executor)
+            final String connectionString, final RetryPolicy retryPolicy, final ScheduledExecutorService executor)
             throws EventHubException, IOException {
         final ConnectionStringBuilder connStr = new ConnectionStringBuilder(connectionString);
         final EventHubClientImpl eventHubClient = new EventHubClientImpl(connStr, executor);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
@@ -114,7 +114,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                             if (TRACE_LOGGER.isInfoEnabled()) {
                                 TRACE_LOGGER.info(
                                         String.format(Locale.US,
-                                                "path[%s], linkName[%s] - Reschedule operation timer, current: [%s], remaining: [%s] secs",
+                                                "clientId[%s], path[%s], linkName[%s] - Reschedule operation timer, current: [%s], remaining: [%s] secs",
+                                                getClientId(),
                                                 receivePath,
                                                 receiveLink.getName(),
                                                 Instant.now(),
@@ -151,7 +152,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                                             if (TRACE_LOGGER.isDebugEnabled()) {
                                                 TRACE_LOGGER.debug(
                                                         String.format(Locale.US,
-                                                                "path[%s], linkName[%s] - token renewed", receivePath, receiveLink.getName()));
+                                                                "clientId[%s], path[%s], linkName[%s] - token renewed",
+                                                                getClientId(), receivePath, receiveLink.getName()));
                                             }
                                         }
 
@@ -160,7 +162,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                                             if (TRACE_LOGGER.isInfoEnabled()) {
                                                 TRACE_LOGGER.info(
                                                         String.format(Locale.US,
-                                                                "path[%s], linkName[%s], tokenRenewalFailure[%s]", receivePath, receiveLink.getName(), error.getMessage()));
+                                                                "clientId[%s], path[%s], linkName[%s], tokenRenewalFailure[%s]",
+                                                                getClientId(), receivePath, receiveLink.getName(), error.getMessage()));
                                             }
                                         }
                                     });
@@ -168,7 +171,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                             if (TRACE_LOGGER.isInfoEnabled()) {
                                 TRACE_LOGGER.info(
                                         String.format(Locale.US,
-                                                "path[%s], linkName[%s], tokenRenewalScheduleFailure[%s]", receivePath, receiveLink.getName(), exception.getMessage()));
+                                                "clientId[%s], path[%s], linkName[%s], tokenRenewalScheduleFailure[%s]",
+                                                getClientId(), receivePath, receiveLink.getName(), exception.getMessage()));
                             }
                         }
                     }
@@ -247,8 +251,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
         if (maxMessageCount <= 0 || maxMessageCount > this.prefetchCount) {
             onReceive.completeExceptionally(new IllegalArgumentException(String.format(
                     Locale.US,
-                    "maxEventCount(%s) should be a positive number and should be less than prefetchCount(%s)",
-                    maxMessageCount, this.prefetchCount)));
+                    "Entity(%s): maxEventCount(%s) should be a positive number and should be less than prefetchCount(%s)",
+                    this.receivePath, maxMessageCount, this.prefetchCount)));
             return onReceive;
         }
 
@@ -256,9 +260,10 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
             if (TRACE_LOGGER.isInfoEnabled()) {
                 TRACE_LOGGER.info(
                         String.format(Locale.US,
-                                "path[%s], linkName[%s] - schedule operation timer, current: [%s], remaining: [%s] secs",
-                                receivePath,
-                                receiveLink.getName(),
+                                "clientId[%s], path[%s], linkName[%s] - schedule operation timer, current: [%s], remaining: [%s] secs",
+                                this.getClientId(),
+                                this.receivePath,
+                                this.receiveLink.getName(),
                                 Instant.now(),
                                 this.receiveTimeout.getSeconds()));
             }
@@ -302,8 +307,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
             this.sendFlow(this.prefetchCount - this.prefetchedMessages.size());
 
             if (TRACE_LOGGER.isInfoEnabled()) {
-                TRACE_LOGGER.info(String.format("receiverPath[%s], linkname[%s], updated-link-credit[%s], sentCredits[%s]",
-                        this.receivePath, this.receiveLink.getName(), this.receiveLink.getCredit(), this.prefetchCount));
+                TRACE_LOGGER.info(String.format("clientId[%s], receiverPath[%s], linkName[%s], updated-link-credit[%s], sentCredits[%s]",
+                        this.getClientId(), this.receivePath, this.receiveLink.getName(), this.receiveLink.getCredit(), this.prefetchCount));
             }
         } else {
             synchronized (this.errorConditionLock) {
@@ -332,8 +337,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                     } catch (IOException | RejectedExecutionException schedulerException) {
                         if (TRACE_LOGGER.isWarnEnabled()) {
                             TRACE_LOGGER.warn(
-                                    String.format(Locale.US, "receiverPath[%s], scheduling createLink encountered error: %s",
-                                            this.receivePath, schedulerException.getLocalizedMessage()));
+                                    String.format(Locale.US, "clientId[%s], receiverPath[%s], scheduling createLink encountered error: %s",
+                                            this.getClientId(), this.receivePath, schedulerException.getLocalizedMessage()));
                         }
 
                         this.cancelOpen(schedulerException);
@@ -387,7 +392,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
             }
 
             final Exception completionException = exception == null
-                    ? new EventHubException(true, "Client encountered transient error for unknown reasons, please retry the operation.")
+                    ? new EventHubException(true, String.format(Locale.US,
+                    "Entity(%s): client encountered transient error for unknown reasons, please retry the operation.", this.receivePath))
                     : exception;
 
             this.onOpenComplete(completionException);
@@ -414,8 +420,9 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                     recreateScheduled = false;
                     if (TRACE_LOGGER.isWarnEnabled()) {
                         TRACE_LOGGER.warn(
-                                String.format(Locale.US, "receiverPath[%s], linkName[%s], scheduling createLink encountered error: %s",
-                                        MessageReceiver.this.receivePath,
+                                String.format(Locale.US, "clientId[%s], receiverPath[%s], linkName[%s], scheduling createLink encountered error: %s",
+                                        this.getClientId(),
+                                        this.receivePath,
                                         this.receiveLink.getName(), ignore.getLocalizedMessage()));
                     }
                 }
@@ -570,8 +577,8 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
             this.nextCreditToFlow = 0;
 
             if (TRACE_LOGGER.isDebugEnabled()) {
-                TRACE_LOGGER.debug(String.format("receiverPath[%s], linkname[%s], updated-link-credit[%s], sentCredits[%s], ThreadId[%s]",
-                        this.receivePath, this.receiveLink.getName(), this.receiveLink.getCredit(), tempFlow, Thread.currentThread().getId()));
+                TRACE_LOGGER.debug(String.format("clientId[%s], receiverPath[%s], linkName[%s], updated-link-credit[%s], sentCredits[%s], ThreadId[%s]",
+                        this.getClientId(), this.receivePath, this.receiveLink.getName(), this.receiveLink.getCredit(), tempFlow, Thread.currentThread().getId()));
             }
         }
     }
@@ -593,10 +600,11 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                                     String.format(Locale.US, "Open operation on entity(%s) timed out at %s.",
                                             MessageReceiver.this.receivePath, ZonedDateTime.now()),
                                     lastReportedLinkError);
+
                             if (TRACE_LOGGER.isWarnEnabled()) {
                                 TRACE_LOGGER.warn(
-                                        String.format(Locale.US, "receiverPath[%s], Open call timedout", MessageReceiver.this.receivePath),
-                                        operationTimedout);
+                                        String.format(Locale.US, "clientId[%s], receiverPath[%s], Open call timed out",
+                                                MessageReceiver.this.getClientId(), MessageReceiver.this.receivePath), operationTimedout);
                             }
 
                             ExceptionUtil.completeExceptionally(linkOpen.getWork(), operationTimedout, MessageReceiver.this);
@@ -629,10 +637,13 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                                 link = MessageReceiver.this.receiveLink;
                             }
 
-                            final Exception operationTimedout = new TimeoutException(String.format(Locale.US, "%s operation on Receive Link(%s) timed out at %s", "Close", link.getName(), ZonedDateTime.now()));
+                            final Exception operationTimedout = new TimeoutException(String.format(Locale.US, "Close operation on Receive Link(%s) timed out at %s",
+                                    link.getName(), ZonedDateTime.now()));
+
                             if (TRACE_LOGGER.isInfoEnabled()) {
                                 TRACE_LOGGER.info(
-                                        String.format(Locale.US, "receiverPath[%s], linkName[%s], %s call timedout", MessageReceiver.this.receivePath, link.getName(), "Close"),
+                                        String.format(Locale.US, "clientId[%s], receiverPath[%s], linkName[%s], Close call timed out",
+                                                MessageReceiver.this.getClientId(), MessageReceiver.this.receivePath, link.getName()),
                                         operationTimedout);
                             }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
@@ -706,13 +706,10 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                     public void onEvent() {
                         if (receiveLink != null && receiveLink.getLocalState() != EndpointState.CLOSED) {
                             receiveLink.close();
-                        }
-
-                        if (closeTimer != null && !closeTimer.isCancelled()) {
+                        } else if (closeTimer != null && !closeTimer.isCancelled()) {
                             closeTimer.cancel(false);
+                            linkClose.complete(null);
                         }
-
-                        linkClose.complete(null);
                     }
                 });
             } catch (IOException | RejectedExecutionException schedulerException) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageReceiver.java
@@ -717,8 +717,11 @@ public final class MessageReceiver extends ClientEntity implements AmqpReceiver,
                     public void onEvent() {
                         if (receiveLink != null && receiveLink.getLocalState() != EndpointState.CLOSED) {
                             receiveLink.close();
-                        } else if (closeTimer != null && !closeTimer.isCancelled()) {
-                            closeTimer.cancel(false);
+                        } else if (receiveLink == null || receiveLink.getRemoteState() == EndpointState.CLOSED) {
+                            if (closeTimer != null && !closeTimer.isCancelled()) {
+                                closeTimer.cancel(false);
+                            }
+
                             linkClose.complete(null);
                         }
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
@@ -889,13 +889,10 @@ public final class MessageSender extends ClientEntity implements AmqpSender, Err
                     public void onEvent() {
                         if (sendLink != null && sendLink.getLocalState() != EndpointState.CLOSED) {
                             sendLink.close();
-                        }
-
-                        if (closeTimer != null && !closeTimer.isCancelled()) {
+                        } else if (closeTimer != null && !closeTimer.isCancelled()) {
                             closeTimer.cancel(false);
+                            linkClose.complete(null);
                         }
-
-                        linkClose.complete(null);
                     }
                 });
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessageSender.java
@@ -914,8 +914,11 @@ public final class MessageSender extends ClientEntity implements AmqpSender, Err
                     public void onEvent() {
                         if (sendLink != null && sendLink.getLocalState() != EndpointState.CLOSED) {
                             sendLink.close();
-                        } else if (closeTimer != null && !closeTimer.isCancelled()) {
-                            closeTimer.cancel(false);
+                        } else if (sendLink == null || sendLink.getRemoteState() == EndpointState.CLOSED) {
+                            if (closeTimer != null && !closeTimer.isCancelled()) {
+                                closeTimer.cancel(false);
+                            }
+
                             linkClose.complete(null);
                         }
                     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -231,14 +231,16 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
     @Override
     public void onConnectionError(ErrorCondition error) {
         if (TRACE_LOGGER.isWarnEnabled()) {
-            TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: hostname[%s], error[%s]",
+            TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: messagingFactory[%s], hostname[%s], error[%s]",
+                    this.getClientId(),
                     this.hostName,
                     error != null ? error.getDescription() : "n/a"));
         }
 
         if (!this.open.isDone()) {
             if (TRACE_LOGGER.isWarnEnabled()) {
-                TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: hostname[%s], open hasn't complete, stopping the reactor",
+                TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: messagingFactory[%s], hostname[%s], open hasn't complete, stopping the reactor",
+                        this.getClientId(),
                         this.hostName));
             }
 
@@ -252,7 +254,8 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
             for (Link link : oldRegisteredLinksCopy) {
                 if (link.getLocalState() != EndpointState.CLOSED && link.getRemoteState() != EndpointState.CLOSED) {
                     if (TRACE_LOGGER.isWarnEnabled()) {
-                        TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: hostname[%s], closing link [%s]",
+                        TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: messagingFactory[%s], hostname[%s], closing link [%s]",
+                                this.getClientId(),
                                 this.hostName, link.getName()));
                     }
 
@@ -265,7 +268,8 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
             // in connection recreation we depend on currentConnection state to evaluate need for recreation
             if (oldConnection.getLocalState() != EndpointState.CLOSED) {
                 if (TRACE_LOGGER.isWarnEnabled()) {
-                    TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: hostname[%s], closing current connection",
+                    TRACE_LOGGER.warn(String.format(Locale.US, "onConnectionError: messagingFactory[%s], hostname[%s], closing current connection",
+                            this.getClientId(),
                             this.hostName));
                 }
 

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -46,7 +46,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
                                   final Long epoch,
                                   final boolean isEpochReceiver,
                                   final ReceiverOptions receiverOptions,
-                                  final Executor executor) {
+                                  final ScheduledExecutorService executor) {
         super(null, null, executor);
 
         this.underlyingFactory = factory;
@@ -72,8 +72,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
                                                        final long epoch,
                                                        final boolean isEpochReceiver,
                                                        ReceiverOptions receiverOptions,
-                                                       final Executor executor)
-            throws EventHubException {
+                                                       final ScheduledExecutorService executor) {
         if (epoch < NULL_EPOCH) {
             throw new IllegalArgumentException("epoch cannot be a negative value. Please specify a zero or positive long value.");
         }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
@@ -47,7 +47,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
                                   final boolean isEpochReceiver,
                                   final ReceiverOptions receiverOptions,
                                   final ScheduledExecutorService executor) {
-        super(null, null, executor);
+        super("PartitionReceiverImpl".concat(StringUtil.getRandomString()), null, executor);
 
         this.underlyingFactory = factory;
         this.eventHubName = eventHubName;
@@ -95,7 +95,7 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
 
     private CompletableFuture<Void> createInternalReceiver() {
         return MessageReceiver.create(this.underlyingFactory,
-                StringUtil.getRandomString(),
+                this.getClientId().concat("-InternalReceiver"),
                 String.format("%s/ConsumerGroups/%s/Partitions/%s", this.eventHubName, this.consumerGroupName, this.partitionId),
                 this.receiverOptions.getPrefetchCount(), this)
                 .thenAcceptAsync(new Consumer<MessageReceiver>() {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionReceiverImpl.java
@@ -179,6 +179,8 @@ final class PartitionReceiverImpl extends ClientEntity implements ReceiverSettin
                             "Unexpected value for parameter 'receiveHandler'. PartitionReceiver was already registered with a PartitionReceiveHandler instance. Only 1 instance can be registered.");
 
                 this.receivePump = new ReceivePump(
+                        this.eventHubName,
+                        this.consumerGroupName,
                         new ReceivePump.IPartitionReceiver() {
                             @Override
                             public CompletableFuture<Iterable<EventData>> receive(int maxBatchSize) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
@@ -19,7 +19,7 @@ final class PartitionSenderImpl extends ClientEntity implements PartitionSender 
     private volatile MessageSender internalSender;
 
     private PartitionSenderImpl(final MessagingFactory factory, final String eventHubName, final String partitionId, final ScheduledExecutorService executor) {
-        super(null, null, executor);
+        super("PartitionSenderImpl".concat(StringUtil.getRandomString()), null, executor);
 
         this.partitionId = partitionId;
         this.eventHubName = eventHubName;
@@ -40,7 +40,7 @@ final class PartitionSenderImpl extends ClientEntity implements PartitionSender 
     }
 
     private CompletableFuture<Void> createInternalSender() throws EventHubException {
-        return MessageSender.create(this.factory, StringUtil.getRandomString(),
+        return MessageSender.create(this.factory, this.getClientId().concat("-InternalSender"),
                 String.format("%s/Partitions/%s", this.eventHubName, this.partitionId))
                 .thenAcceptAsync(new Consumer<MessageSender>() {
                     public void accept(MessageSender a) {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/PartitionSenderImpl.java
@@ -7,7 +7,7 @@ package com.microsoft.azure.eventhubs.impl;
 import com.microsoft.azure.eventhubs.*;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -18,7 +18,7 @@ final class PartitionSenderImpl extends ClientEntity implements PartitionSender 
 
     private volatile MessageSender internalSender;
 
-    private PartitionSenderImpl(final MessagingFactory factory, final String eventHubName, final String partitionId, final Executor executor) {
+    private PartitionSenderImpl(final MessagingFactory factory, final String eventHubName, final String partitionId, final ScheduledExecutorService executor) {
         super(null, null, executor);
 
         this.partitionId = partitionId;
@@ -29,7 +29,7 @@ final class PartitionSenderImpl extends ClientEntity implements PartitionSender 
     static CompletableFuture<PartitionSender> Create(final MessagingFactory factory,
                                                      final String eventHubName,
                                                      final String partitionId,
-                                                     final Executor executor) throws EventHubException {
+                                                     final ScheduledExecutorService executor) throws EventHubException {
         final PartitionSenderImpl sender = new PartitionSenderImpl(factory, eventHubName, partitionId, executor);
         return sender.createInternalSender()
                 .thenApplyAsync(new Function<Void, PartitionSender>() {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReactorDispatcher.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReactorDispatcher.java
@@ -121,7 +121,7 @@ public final class ReactorDispatcher {
             } catch (ClosedChannelException ignorePipeClosedDuringReactorShutdown) {
                 TRACE_LOGGER.info("ScheduleHandler.run() failed with an error", ignorePipeClosedDuringReactorShutdown);
             } catch (IOException ioException) {
-                TRACE_LOGGER.info("ScheduleHandler.run() failed with an error", ioException);
+                TRACE_LOGGER.warn("ScheduleHandler.run() failed with an error", ioException);
                 throw new RuntimeException(ioException);
             }
 
@@ -135,26 +135,26 @@ public final class ReactorDispatcher {
     private final class CloseHandler implements Callback {
         @Override
         public void run(Selectable selectable) {
+            workScheduler.run(null);
+
             try {
                 selectable.getChannel().close();
             } catch (IOException ioException) {
-                TRACE_LOGGER.info("CloseHandler.run() failed with an error", ioException);
+                TRACE_LOGGER.info("CloseHandler.run() getChannel().close() failed with an error", ioException);
             }
 
             try {
                 if (ioSignal.sink().isOpen())
                     ioSignal.sink().close();
             } catch (IOException ioException) {
-                TRACE_LOGGER.info("CloseHandler.run() failed with an error", ioException);
+                TRACE_LOGGER.info("CloseHandler.run() sink().close() failed with an error", ioException);
             }
-
-            workScheduler.run(null);
 
             try {
                 if (ioSignal.source().isOpen())
                     ioSignal.source().close();
             } catch (IOException ioException) {
-                TRACE_LOGGER.info("CloseHandler.run() failed with an error", ioException);
+                TRACE_LOGGER.info("CloseHandler.run() source().close() failed with an error", ioException);
             }
         }
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReactorDispatcher.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReactorDispatcher.java
@@ -80,7 +80,7 @@ public final class ReactorDispatcher {
 
         // throw when the pipe is in closed state - in which case,
         // signalling the new event-dispatch will fail
-        if (!this.ioSignal.source().isOpen() || !this.ioSignal.sink().isOpen()) {
+        if (!this.ioSignal.sink().isOpen()) {
             throw new RejectedExecutionException("ReactorDispatcher instance is closed.");
         }
     }
@@ -135,20 +135,14 @@ public final class ReactorDispatcher {
     private final class CloseHandler implements Callback {
         @Override
         public void run(Selectable selectable) {
-            workScheduler.run(null);
-
-            try {
-                selectable.getChannel().close();
-            } catch (IOException ioException) {
-                TRACE_LOGGER.info("CloseHandler.run() getChannel().close() failed with an error", ioException);
-            }
-
             try {
                 if (ioSignal.sink().isOpen())
                     ioSignal.sink().close();
             } catch (IOException ioException) {
                 TRACE_LOGGER.info("CloseHandler.run() sink().close() failed with an error", ioException);
             }
+
+            workScheduler.run(null);
 
             try {
                 if (ioSignal.source().isOpen())

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReceiveLinkHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ReceiveLinkHandler.java
@@ -37,7 +37,7 @@ public final class ReceiveLinkHandler extends BaseLinkHandler {
 
             if (TRACE_LOGGER.isInfoEnabled()) {
                 TRACE_LOGGER.info(
-                        String.format("linkName[%s], localSource[%s]", receiver.getName(), receiver.getSource()));
+                        String.format("onLinkLocalOpen linkName[%s], localSource[%s]", receiver.getName(), receiver.getSource()));
             }
         }
     }
@@ -45,11 +45,12 @@ public final class ReceiveLinkHandler extends BaseLinkHandler {
     @Override
     public void onLinkRemoteOpen(Event event) {
         Link link = event.getLink();
-        if (link != null && link instanceof Receiver) {
+        if (link instanceof Receiver) {
             Receiver receiver = (Receiver) link;
             if (link.getRemoteSource() != null) {
                 if (TRACE_LOGGER.isInfoEnabled()) {
-                    TRACE_LOGGER.info(String.format(Locale.US, "linkName[%s], remoteSource[%s]", receiver.getName(), link.getRemoteSource()));
+                    TRACE_LOGGER.info(String.format(Locale.US, "onLinkRemoteOpen linkName[%s], remoteSource[%s]",
+                            receiver.getName(), link.getRemoteSource()));
                 }
 
                 synchronized (this.firstResponse) {
@@ -59,7 +60,8 @@ public final class ReceiveLinkHandler extends BaseLinkHandler {
             } else {
                 if (TRACE_LOGGER.isInfoEnabled()) {
                     TRACE_LOGGER.info(
-                            String.format(Locale.US, "linkName[%s], remoteTarget[null], remoteSource[null], action[waitingForError]", receiver.getName()));
+                            String.format(Locale.US, "onLinkRemoteOpen linkName[%s], remoteTarget[null], " +
+                                    "remoteSource[null], action[waitingForError]", receiver.getName()));
                 }
             }
         }
@@ -89,8 +91,9 @@ public final class ReceiveLinkHandler extends BaseLinkHandler {
                 if (TRACE_LOGGER.isWarnEnabled()) {
                     TRACE_LOGGER.warn(
                             receiveLink != null
-                                    ? String.format(Locale.US, "linkName[%s], updatedLinkCredit[%s], remoteCredit[%s], remoteCondition[%s], delivery.isSettled[%s]",
-                                        receiveLink.getName(), receiveLink.getCredit(), receiveLink.getRemoteCredit(), receiveLink.getRemoteCondition(), delivery.isSettled())
+                                    ? String.format(Locale.US, "onDelivery linkName[%s], updatedLinkCredit[%s], remoteCredit[%s], " +
+                                            "remoteCondition[%s], delivery.isSettled[%s]",
+                                    receiveLink.getName(), receiveLink.getCredit(), receiveLink.getRemoteCredit(), receiveLink.getRemoteCondition(), delivery.isSettled())
                                     : String.format(Locale.US, "delivery.isSettled[%s]", delivery.isSettled()));
                 }
             } else {
@@ -100,7 +103,8 @@ public final class ReceiveLinkHandler extends BaseLinkHandler {
 
         if (TRACE_LOGGER.isTraceEnabled() && receiveLink != null) {
             TRACE_LOGGER.trace(
-                    String.format(Locale.US, "linkName[%s], updatedLinkCredit[%s], remoteCredit[%s], remoteCondition[%s], delivery.isPartial[%s]",
+                    String.format(Locale.US, "onDelivery linkName[%s], updatedLinkCredit[%s], remoteCredit[%s], " +
+                                    "remoteCondition[%s], delivery.isPartial[%s]",
                             receiveLink.getName(), receiveLink.getCredit(), receiveLink.getRemoteCredit(), receiveLink.getRemoteCondition(), delivery.isPartial()));
         }
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SchedulerProvider.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SchedulerProvider.java
@@ -2,5 +2,5 @@ package com.microsoft.azure.eventhubs.impl;
 
 interface SchedulerProvider {
 
-    ReactorDispatcher getReactorScheduler();
+    ReactorDispatcher getReactorDispatcher();
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SendLinkHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SendLinkHandler.java
@@ -28,13 +28,24 @@ public class SendLinkHandler extends BaseLinkHandler {
     }
 
     @Override
+    public void onLinkLocalOpen(Event event) {
+        Link link = event.getLink();
+        if (link instanceof Sender) {
+            Sender sender = (Sender) link;
+            if (TRACE_LOGGER.isInfoEnabled()) {
+                TRACE_LOGGER.info(String.format("onLinkLocalOpen linkName[%s], localTarget[%s]", sender.getName(), sender.getTarget()));
+            }
+        }
+    }
+
+    @Override
     public void onLinkRemoteOpen(Event event) {
         Link link = event.getLink();
-        if (link != null && link instanceof Sender) {
+        if (link instanceof Sender) {
             Sender sender = (Sender) link;
             if (link.getRemoteTarget() != null) {
                 if (TRACE_LOGGER.isInfoEnabled()) {
-                    TRACE_LOGGER.info(String.format(Locale.US, "linkName[%s], remoteTarget[%s]", sender.getName(), link.getRemoteTarget()));
+                    TRACE_LOGGER.info(String.format(Locale.US, "onLinkRemoteOpen linkName[%s], remoteTarget[%s]", sender.getName(), link.getRemoteTarget()));
                 }
 
                 synchronized (this.firstFlow) {
@@ -44,7 +55,7 @@ public class SendLinkHandler extends BaseLinkHandler {
             } else {
                 if (TRACE_LOGGER.isInfoEnabled()) {
                     TRACE_LOGGER.info(
-                            String.format(Locale.US, "linkName[%s], remoteTarget[null], remoteSource[null], action[waitingForError]", sender.getName()));
+                            String.format(Locale.US, "onLinkRemoteOpen linkName[%s], remoteTarget[null], remoteSource[null], action[waitingForError]", sender.getName()));
                 }
             }
         }
@@ -59,7 +70,7 @@ public class SendLinkHandler extends BaseLinkHandler {
 
             if (TRACE_LOGGER.isTraceEnabled()) {
                 TRACE_LOGGER.trace(
-                        "linkName[" + sender.getName() +
+                        "onDelivery linkName[" + sender.getName() +
                                 "], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getRemoteCredit() + "], deliveryState[" + delivery.getRemoteState() +
                                 "], delivery.isBuffered[" + delivery.isBuffered() + "], delivery.id[" + new String(delivery.getTag()) + "]");
             }
@@ -86,7 +97,7 @@ public class SendLinkHandler extends BaseLinkHandler {
         this.msgSender.onFlow(sender.getRemoteCredit());
 
         if (TRACE_LOGGER.isDebugEnabled()) {
-            TRACE_LOGGER.debug("linkName[" + sender.getName() + "], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getCredit() + "]");
+            TRACE_LOGGER.debug("onLinkFlow linkName[" + sender.getName() + "], unsettled[" + sender.getUnsettled() + "], credit[" + sender.getCredit() + "]");
         }
     }
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/SessionHandler.java
@@ -13,6 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.function.BiConsumer;
@@ -24,18 +25,28 @@ public class SessionHandler extends BaseHandler {
     private final String entityName;
     private final Consumer<Session> onRemoteSessionOpen;
     private final BiConsumer<ErrorCondition, Exception> onRemoteSessionOpenError;
+    private final Duration openTimeout;
 
     private boolean sessionCreated = false;
     private boolean sessionOpenErrorDispatched = false;
 
-    public SessionHandler(final String entityName, final Consumer<Session> onRemoteSessionOpen, final BiConsumer<ErrorCondition, Exception> onRemoteSessionOpenError) {
+    public SessionHandler(final String entityName,
+                          final Consumer<Session> onRemoteSessionOpen,
+                          final BiConsumer<ErrorCondition, Exception> onRemoteSessionOpenError,
+                          final Duration openTimeout) {
         this.entityName = entityName;
         this.onRemoteSessionOpenError = onRemoteSessionOpenError;
         this.onRemoteSessionOpen = onRemoteSessionOpen;
+        this.openTimeout = openTimeout;
     }
 
     @Override
     public void onSessionLocalOpen(Event e) {
+        if (TRACE_LOGGER.isInfoEnabled()) {
+            TRACE_LOGGER.info(String.format(Locale.US, "onSessionLocalOpen entityName[%s], condition[%s]", this.entityName,
+                    e.getSession().getCondition() == null ? "none" : e.getSession().getCondition().toString()));
+        }
+
         if (this.onRemoteSessionOpenError != null) {
 
             ReactorHandler reactorHandler = null;
@@ -53,12 +64,11 @@ public class SessionHandler extends BaseHandler {
             final Session session = e.getSession();
 
             try {
-
-                reactorDispatcher.invoke(ClientConstants.SESSION_OPEN_TIMEOUT_IN_MS, new SessionTimeoutHandler(session));
+                reactorDispatcher.invoke((int) this.openTimeout.toMillis(), new SessionTimeoutHandler(session));
             } catch (IOException ignore) {
-
                 if (TRACE_LOGGER.isWarnEnabled()) {
-                    TRACE_LOGGER.warn(String.format(Locale.US, "entityName[%s], reactorDispatcherError[%s]", this.entityName, ignore.getMessage()));
+                    TRACE_LOGGER.warn(String.format(Locale.US, "onSessionLocalOpen entityName[%s], reactorDispatcherError[%s]",
+                            this.entityName, ignore.getMessage()));
                 }
 
                 session.close();
@@ -66,8 +76,8 @@ public class SessionHandler extends BaseHandler {
                         null,
                         new EventHubException(
                                 false,
-                                String.format("underlying IO of reactorDispatcher faulted with error: %s", ignore.getMessage()),
-                                ignore));
+                                String.format("onSessionLocalOpen entityName[%s], underlying IO of reactorDispatcher faulted with error: %s",
+                                        this.entityName, ignore.getMessage()), ignore));
             }
         }
     }
@@ -88,7 +98,6 @@ public class SessionHandler extends BaseHandler {
         if (this.onRemoteSessionOpen != null)
             this.onRemoteSessionOpen.accept(session);
     }
-
 
     @Override
     public void onSessionLocalClose(Event e) {
@@ -135,6 +144,10 @@ public class SessionHandler extends BaseHandler {
 
             // notify - if connection or transport error'ed out before even session open completed
             if (!sessionCreated && !sessionOpenErrorDispatched) {
+                if (TRACE_LOGGER.isWarnEnabled()) {
+                    TRACE_LOGGER.warn(String.format(Locale.US, "SessionTimeoutHandler.onEvent closing a session" +
+                            "due to a connection/transport error before session open was complete."));
+                }
 
                 final Connection connection = session.getConnection();
 
@@ -157,7 +170,7 @@ public class SessionHandler extends BaseHandler {
                 }
 
                 session.close();
-                onRemoteSessionOpenError.accept(null, new TimeoutException("session creation timedout."));
+                onRemoteSessionOpenError.accept(null, new TimeoutException("session creation timed out."));
             }
         }
     }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/Timer.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/Timer.java
@@ -24,7 +24,7 @@ final class Timer {
         final ScheduledTask scheduledTask = new ScheduledTask(runnable);
         final CompletableFuture<?> taskHandle = scheduledTask.getScheduledFuture();
         try {
-            this.schedulerProvider.getReactorScheduler().invoke((int) runAfter.toMillis(), scheduledTask);
+            this.schedulerProvider.getReactorDispatcher().invoke((int) runAfter.toMillis(), scheduledTask);
         } catch (IOException | RejectedExecutionException e) {
             taskHandle.completeExceptionally(e);
         }

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
@@ -15,7 +15,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 
 public class EventHubClientTest extends ApiTestBase {
 
@@ -25,7 +26,7 @@ public class EventHubClientTest extends ApiTestBase {
         final String consumerGroupName = TestContext.getConsumerGroupName();
         final String partitionId = "0";
         final int noOfClients = 4;
-        final ScheduledThreadPoolExecutor executorService = new ScheduledThreadPoolExecutor(1);
+        final ScheduledExecutorService executorService = Executors.newScheduledThreadPool(1);
 
         @SuppressWarnings("unchecked")
         CompletableFuture<EventHubClient>[] createFutures = new CompletableFuture[noOfClients];

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/concurrency/EventHubClientTest.java
@@ -14,7 +14,8 @@ import com.microsoft.azure.eventhubs.lib.TestContext;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.util.concurrent.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class EventHubClientTest extends ApiTestBase {
 
@@ -24,7 +25,7 @@ public class EventHubClientTest extends ApiTestBase {
         final String consumerGroupName = TestContext.getConsumerGroupName();
         final String partitionId = "0";
         final int noOfClients = 4;
-        final ExecutorService executorService = Executors.newSingleThreadExecutor();
+        final ScheduledThreadPoolExecutor executorService = new ScheduledThreadPoolExecutor(1);
 
         @SuppressWarnings("unchecked")
         CompletableFuture<EventHubClient>[] createFutures = new CompletableFuture[noOfClients];

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
@@ -11,7 +11,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class EventDataBatchTest extends ApiTestBase {
 
@@ -20,7 +20,7 @@ public class EventDataBatchTest extends ApiTestBase {
     @Test(expected = PayloadSizeExceededException.class)
     public void payloadExceededException() throws EventHubException, IOException {
         final ConnectionStringBuilder connStrBuilder = TestContext.getConnectionString();
-        ehClient = EventHubClient.createSync(connStrBuilder.toString(), Executors.newSingleThreadExecutor());
+        ehClient = EventHubClient.createSync(connStrBuilder.toString(), new ScheduledThreadPoolExecutor(1));
 
         final EventDataBatch batch = ehClient.createBatch();
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/eventdata/EventDataBatchTest.java
@@ -11,7 +11,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
 
 public class EventDataBatchTest extends ApiTestBase {
 
@@ -20,7 +20,7 @@ public class EventDataBatchTest extends ApiTestBase {
     @Test(expected = PayloadSizeExceededException.class)
     public void payloadExceededException() throws EventHubException, IOException {
         final ConnectionStringBuilder connStrBuilder = TestContext.getConnectionString();
-        ehClient = EventHubClient.createSync(connStrBuilder.toString(), new ScheduledThreadPoolExecutor(1));
+        ehClient = EventHubClient.createSync(connStrBuilder.toString(), Executors.newScheduledThreadPool(1));
 
         final EventDataBatch batch = ehClient.createBatch();
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/MsgFactoryOpenCloseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/MsgFactoryOpenCloseTest.java
@@ -30,8 +30,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
     public void VerifyTaskQueueEmptyOnMsgFactoryGracefulClose() throws Exception {
 
         final LinkedBlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<>();
-        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                1, 1, 1, TimeUnit.MINUTES, blockingQueue);
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
         try {
             final EventHubClient ehClient = EventHubClient.createSync(
                     TestContext.getConnectionString().toString(),
@@ -60,8 +59,8 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
     public void VerifyTaskQueueEmptyOnMsgFactoryWithPumpGracefulClose() throws Exception {
 
         final LinkedBlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<>();
-        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                1, 1, 1, TimeUnit.MINUTES, blockingQueue);
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
+
         try {
             final EventHubClient ehClient = EventHubClient.createSync(
                     TestContext.getConnectionString().toString(),
@@ -114,8 +113,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
         networkOutageSimulator.setFaultType(FaultInjectingReactorFactory.FaultType.NetworkOutage);
 
         final LinkedBlockingQueue<Runnable> blockingQueue = new LinkedBlockingQueue<>();
-        final ThreadPoolExecutor executor = new ThreadPoolExecutor(
-                1, 1, 1, TimeUnit.MINUTES, blockingQueue);
+        final ScheduledThreadPoolExecutor executor = new ScheduledThreadPoolExecutor(1);
 
         try {
             final CompletableFuture<MessagingFactory> openFuture = MessagingFactory.createFromConnectionString(
@@ -140,7 +138,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToEventHubClient() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
         testClosed.shutdown();
 
         EventHubClient.createSync(
@@ -150,7 +148,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToSendOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -165,7 +163,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToReceiveOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final PartitionReceiver temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -180,7 +178,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToCreateLinkOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -195,7 +193,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToCreateSenderOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -209,7 +207,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceToCreateReceiverOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -223,7 +221,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceThenMgmtOperation() throws Throwable {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -241,7 +239,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceThenFactoryCloseOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final EventHubClient temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -255,7 +253,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceThenSenderCloseOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final PartitionSender temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),
@@ -269,7 +267,7 @@ public class MsgFactoryOpenCloseTest extends ApiTestBase {
 
     @Test(expected = RejectedExecutionException.class)
     public void SupplyClosedExecutorServiceThenReceiverCloseOperation() throws Exception {
-        final ExecutorService testClosed = Executors.newWorkStealingPool();
+        final ScheduledThreadPoolExecutor testClosed = new ScheduledThreadPoolExecutor(1);
 
         final PartitionReceiver temp = EventHubClient.createSync(
                 TestContext.getConnectionString().toString(),

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
@@ -12,6 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ReactorFaultTest extends ApiTestBase {
@@ -26,27 +27,38 @@ public class ReactorFaultTest extends ApiTestBase {
     @Test()
     public void VerifyReactorRestartsOnProtonBugs() throws Exception {
         final EventHubClient eventHubClient = EventHubClient.createSync(connStr.toString(), TestContext.EXECUTOR_SERVICE);
-
         try {
             final PartitionReceiver partitionReceiver = eventHubClient.createEpochReceiverSync(
                     "$default", "0", EventPosition.fromStartOfStream(), System.currentTimeMillis());
+            partitionReceiver.receiveSync(100);
+
+            new ScheduledThreadPoolExecutor(1).schedule(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        final Field factoryField = EventHubClientImpl.class.getDeclaredField("underlyingFactory");
+                        factoryField.setAccessible(true);
+                        final MessagingFactory underlyingFactory = (MessagingFactory) factoryField.get(eventHubClient);
+
+                        final Field reactorField = MessagingFactory.class.getDeclaredField("reactor");
+                        reactorField.setAccessible(true);
+                        final Reactor reactor = (Reactor) reactorField.get(underlyingFactory);
+
+                        org.apache.qpid.proton.engine.Handler handler = reactor.getHandler();
+                        handler.add(new BaseHandler() {
+                            @Override
+                            public void handle(org.apache.qpid.proton.engine.Event e) {
+                                throw new NullPointerException();
+                            }
+                        });
+                    } catch (Exception e) {
+                        Assert.fail(e.getMessage());
+                    }
+                }
+            }, 2, TimeUnit.SECONDS);
 
             try {
-                final Field factoryField = EventHubClientImpl.class.getDeclaredField("underlyingFactory");
-                factoryField.setAccessible(true);
-                final MessagingFactory underlyingFactory = (MessagingFactory) factoryField.get(eventHubClient);
-
-                final Field reactorField = MessagingFactory.class.getDeclaredField("reactor");
-                reactorField.setAccessible(true);
-                final Reactor reactor = (Reactor) reactorField.get(underlyingFactory);
-
-                org.apache.qpid.proton.engine.Handler handler = reactor.getHandler();
-                handler.add(new BaseHandler() {
-                    @Override
-                    public void handle(org.apache.qpid.proton.engine.Event e) {
-                        throw new NullPointerException();
-                    }
-                });
+                Thread.sleep(4000);
 
                 final Iterable<EventData> events = partitionReceiver.receiveSync(100);
                 Assert.assertTrue(events != null && events.iterator().hasNext());

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/exceptioncontracts/ReactorFaultTest.java
@@ -12,7 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.lang.reflect.Field;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class ReactorFaultTest extends ApiTestBase {
@@ -32,7 +32,7 @@ public class ReactorFaultTest extends ApiTestBase {
                     "$default", "0", EventPosition.fromStartOfStream(), System.currentTimeMillis());
             partitionReceiver.receiveSync(100);
 
-            new ScheduledThreadPoolExecutor(1).schedule(new Runnable() {
+            Executors.newScheduledThreadPool(1).schedule(new Runnable() {
                 @Override
                 public void run() {
                     try {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/TestContext.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/TestContext.java
@@ -6,11 +6,13 @@ package com.microsoft.azure.eventhubs.lib;
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 
+import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public final class TestContext {
-    public final static ScheduledExecutorService EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
+
+    public final static ScheduledExecutorService EXECUTOR_SERVICE = Executors.newScheduledThreadPool(1);
 
     final static String EVENT_HUB_CONNECTION_STRING_ENV_NAME = "EVENT_HUB_CONNECTION_STRING";
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/TestContext.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/lib/TestContext.java
@@ -6,11 +6,11 @@ package com.microsoft.azure.eventhubs.lib;
 
 import com.microsoft.azure.eventhubs.ConnectionStringBuilder;
 
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public final class TestContext {
-    public final static ExecutorService EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+    public final static ScheduledExecutorService EXECUTOR_SERVICE = new ScheduledThreadPoolExecutor(1);
 
     final static String EVENT_HUB_CONNECTION_STRING_ENV_NAME = "EVENT_HUB_CONNECTION_STRING";
 

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/ReceivePumpTest.java
@@ -32,6 +32,7 @@ public class ReceivePumpTest {
     public void testPumpOnReceiveEventFlow() throws Exception {
         final CompletableFuture<Void> pumpRun = new CompletableFuture<>();
         final ReceivePump receivePump = new ReceivePump(
+                "eventhub1", "consumerGroup1",
                 new ReceivePump.IPartitionReceiver() {
                     @Override
                     public CompletableFuture<Iterable<EventData>> receive(int maxBatchSize) {
@@ -82,6 +83,7 @@ public class ReceivePumpTest {
     public void testPumpReceiveTransientErrorsPropagated() throws Exception {
         final CompletableFuture<Void> pumpRun = new CompletableFuture<>();
         final ReceivePump receivePump = new ReceivePump(
+                "eventhub1", "consumerGroup1",
                 new ReceivePump.IPartitionReceiver() {
                     @Override
                     public CompletableFuture<Iterable<EventData>> receive(int maxBatchSize) {
@@ -128,6 +130,7 @@ public class ReceivePumpTest {
     public void testPumpReceiveExceptionsPropagated() throws Exception {
         final CompletableFuture<Void> pumpRun = new CompletableFuture<>();
         final ReceivePump receivePump = new ReceivePump(
+                "eventhub1", "consumerGroup1",
                 new ReceivePump.IPartitionReceiver() {
                     @Override
                     public CompletableFuture<Iterable<EventData>> receive(int maxBatchSize) {
@@ -175,6 +178,7 @@ public class ReceivePumpTest {
         final String runtimeExceptionMsg = "random exception";
         final CompletableFuture<Void> pumpRun = new CompletableFuture<>();
         final ReceivePump receivePump = new ReceivePump(
+                "eventhub1", "consumerGroup1",
                 new ReceivePump.IPartitionReceiver() {
                     @Override
                     public CompletableFuture<Iterable<EventData>> receive(int maxBatchSize) {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/sendrecv/RequestResponseTest.java
@@ -50,7 +50,7 @@ public class RequestResponseTest extends ApiTestBase {
     @Test()
     public void testRequestResponse() throws Exception {
 
-        final ReactorDispatcher dispatcher = factory.getReactorScheduler();
+        final ReactorDispatcher dispatcher = factory.getReactorDispatcher();
         final RequestResponseChannel requestResponseChannel = new RequestResponseChannel(
                 "reqresp",
                 ClientConstants.MANAGEMENT_ADDRESS,


### PR DESCRIPTION
## Description
This pull request contains the following changes.

1) Drain pending tasks when recreating the reactor to make sure pending calls get complete.
2) Fix the timeout issue on the close of the receiver and sender.
3) Make session open timeout configurable and use the value of OperationTimeout.
4) When closing the reactor dispatcher, process work items prior to closing the channel.
5) Improve tracing for reactor related components.
6) refactoring codes

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.