### PR TITLE
Handle proton:io errors with meaningful error msg

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConstants.java
@@ -13,6 +13,7 @@ import java.util.Set;
 public final class AmqpConstants {
 
     public static final String APACHE = "apache.org";
+    public static final String PROTON = "proton";
     public static final String VENDOR = "com.microsoft";
     public static final String AMQP_ANNOTATION_FORMAT = "amqp.annotation.%s >%s '%s'";
     public static final String OFFSET_ANNOTATION_NAME = "x-opt-offset";

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ClientConstants.java
@@ -20,6 +20,7 @@ public final class ClientConstants {
     public final static Symbol STORE_LOCK_LOST_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":store-lock-lost");
     public final static Symbol PUBLISHER_REVOKED_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":publisher-revoked");
     public final static Symbol TIMEOUT_ERROR = Symbol.getSymbol(AmqpConstants.VENDOR + ":timeout");
+    public final static Symbol PROTON_IO_ERROR = Symbol.getSymbol(AmqpConstants.PROTON + ":io");
     public final static Symbol TRACKING_ID_PROPERTY = Symbol.getSymbol(AmqpConstants.VENDOR + ":tracking-id");
     public static final int MAX_MESSAGE_LENGTH_BYTES = 256 * 1024;
     public static final int MAX_FRAME_SIZE_BYTES = 64 * 1024;
@@ -76,6 +77,9 @@ public final class ClientConstants {
     public static final String TOKEN_AUDIENCE_FORMAT = "amqp://%s/%s";
     public static final String HTTPS_URI_FORMAT = "https://%s:%s";
     public static final int MAX_RECEIVER_NAME_LENGTH = 64;
+    
+    public static final String COMMUNICATION_EXCEPTION_GENERIC_MESSAGE = "A communication error has occurred. " +
+    		"This may be due to an incorrect host name in your connection string or a problem with your network connection.";
 
     /**
      * This is a constant defined to represent the start of a partition stream in EventHub.

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
@@ -55,6 +55,8 @@ public final class ExceptionUtil {
             return new EventHubException(true, new AmqpException(errorCondition));
         } else if (errorCondition.getCondition() == AmqpErrorCode.ResourceLimitExceeded) {
             return new QuotaExceededException(new AmqpException(errorCondition));
+        } else if (errorCondition.getCondition() == ClientConstants.PROTON_IO_ERROR) {
+        	return new CommunicationException(ClientConstants.COMMUNICATION_EXCEPTION_GENERIC_MESSAGE, null);
         }
 
         return new EventHubException(ClientConstants.DEFAULT_IS_TRANSIENT, errorCondition.getDescription());

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ExceptionUtil.java
@@ -56,7 +56,11 @@ public final class ExceptionUtil {
         } else if (errorCondition.getCondition() == AmqpErrorCode.ResourceLimitExceeded) {
             return new QuotaExceededException(new AmqpException(errorCondition));
         } else if (errorCondition.getCondition() == ClientConstants.PROTON_IO_ERROR) {
-        	return new CommunicationException(ClientConstants.COMMUNICATION_EXCEPTION_GENERIC_MESSAGE, null);
+        	String message = ClientConstants.COMMUNICATION_EXCEPTION_GENERIC_MESSAGE;
+        	if (errorCondition.getDescription() != null) {
+        		message = errorCondition.getDescription();
+        	}
+        	return new CommunicationException(message, null);
         }
 
         return new EventHubException(ClientConstants.DEFAULT_IS_TRANSIENT, errorCondition.getDescription());


### PR DESCRIPTION
## Description

Convert proton:io ErrorCondition into CommunicationException. In some cases, such as DNS resolution failure, the message in the ErrorCondition is null, so substitute a useful generic message in those cases.

This checklist is used to make sure that common guidelines for a pull request are followed.

- [ ] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [ ] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [ ] If applicable, the public code is properly documented.
- [ ] Pull request includes test coverage for the included changes.
- [ ] The code builds without any errors.