### PR TITLE
Minor changes to lease scanner

### DIFF
--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -212,7 +212,12 @@ public final class EventProcessorOptions {
         // Capture handler so it doesn't get set to null between test and use
         Consumer<ExceptionReceivedEventArgs> handler = this.exceptionNotificationHandler;
         if (handler != null) {
-            handler.accept(new ExceptionReceivedEventArgs(hostname, exception, action, partitionId));
+        	try {
+        		handler.accept(new ExceptionReceivedEventArgs(hostname, exception, action, partitionId));
+        	}
+        	catch (Exception e) {
+        		// Swallow and ignore exceptions coming out of user code.
+        	}
         }
     }
 

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/EventProcessorOptions.java
@@ -13,6 +13,9 @@ import java.util.Locale;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /***
  * Options affecting the behavior of the event processor host instance in general.
  */
@@ -27,6 +30,8 @@ public final class EventProcessorOptions {
         return EventPosition.fromStartOfStream();
     };
 
+    private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(EventProcessorOptions.class);
+    
     public EventProcessorOptions() {
     }
 
@@ -216,7 +221,7 @@ public final class EventProcessorOptions {
         		handler.accept(new ExceptionReceivedEventArgs(hostname, exception, action, partitionId));
         	}
         	catch (Exception e) {
-        		// Swallow and ignore exceptions coming out of user code.
+        		TRACE_LOGGER.error("host " + hostname + ": caught exception from user-provided exception notification handler", e);
         	}
         }
     }

--- a/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
+++ b/azure-eventhubs-eph/src/main/java/com/microsoft/azure/eventprocessorhost/PartitionManager.java
@@ -294,6 +294,9 @@ class PartitionManager extends Closable {
                 .whenCompleteAsync((didSteal, e) ->
                 {
                     TRACE_LOGGER.debug(this.hostContext.withHost("Scanning took " + (System.currentTimeMillis() - start)));
+                	if ((e != null) && !(e instanceof ClosingException)) {
+                		TRACE_LOGGER.warn(this.hostContext.withHost("Lease scanner got exception"), e);
+                	}
 
                     onPartitionCheckCompleteTestHook();
 
@@ -309,7 +312,7 @@ class PartitionManager extends Closable {
                         }
                         TRACE_LOGGER.debug(this.hostContext.withHost("Scheduling lease scanner in " + seconds));
                     } else {
-                        TRACE_LOGGER.debug(this.hostContext.withHost("Not scheduling lease scanner due to shutdown"));
+                        TRACE_LOGGER.warn(this.hostContext.withHost("Not scheduling lease scanner due to shutdown"));
                     }
                 }, this.hostContext.getExecutor());
 


### PR DESCRIPTION
## Description

* Add logging if the scanner threw an exception.
* Change logging level to warn when scanner shuts down.
* Scanner can call EventProcessorOptions.notifyOfException, which calls user code. Change notifyOfException to defensively catch any exceptions coming out of user code.