### PR TITLE
Make EventData.SystemProperties completely public

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventData.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/EventData.java
@@ -145,12 +145,20 @@ public interface EventData extends Serializable, Comparable<EventData> {
      * @see SystemProperties#getEnqueuedTime
      */
     SystemProperties getSystemProperties();
+    void setSystemProperties(SystemProperties props);
 
-    class SystemProperties extends HashMap<String, Object> {
+    public class SystemProperties extends HashMap<String, Object> {
         private static final long serialVersionUID = -2827050124966993723L;
 
         public SystemProperties(final HashMap<String, Object> map) {
             super(Collections.unmodifiableMap(map));
+        }
+        
+        public SystemProperties(final long sequenceNumber, final Instant enqueuedTimeUtc, final String offset, final String partitionKey) {
+        	this.put(AmqpConstants.SEQUENCE_NUMBER_ANNOTATION_NAME, sequenceNumber);
+        	this.put(AmqpConstants.ENQUEUED_TIME_UTC_ANNOTATION_NAME, new Date(enqueuedTimeUtc.toEpochMilli()));
+        	this.put(AmqpConstants.OFFSET_ANNOTATION_NAME, offset);
+        	this.put(AmqpConstants.PARTITION_KEY_ANNOTATION_NAME, partitionKey);
         }
 
         public String getOffset() {

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventDataImpl.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/EventDataImpl.java
@@ -146,6 +146,10 @@ public final class EventDataImpl implements EventData {
         return this.systemProperties;
     }
 
+    public void setSystemProperties(EventData.SystemProperties props) {
+    	this.systemProperties = props;
+    }
+
     // This is intended to be used while sending EventData - so EventData.SystemProperties will not be copied over to the AmqpMessage
     Message toAmqpMessage() {
         final Message amqpMessage = Proton.message();


### PR DESCRIPTION
## Description

Porting testability changes from .NET Core to Java: provide full access to EventData's SystemProperties so that a complete EventData can be fabricated in tests.