### PR TITLE
Add CustomHostname connection string parameter

### DIFF
--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/ConnectionStringBuilder.java
@@ -62,16 +62,18 @@ public final class ConnectionStringBuilder {
     final static String SharedAccessKeyConfigName = "SharedAccessKey";
     final static String SharedAccessSignatureConfigName = "SharedAccessSignature";
     final static String TransportTypeConfigName = "TransportType";
+    final static String CustomHostnameConfigName = "CustomHostname";
 
     private static final String AllKeyEnumerateRegex = "(" + HostnameConfigName + "|" + EndpointConfigName + "|" + SharedAccessKeyNameConfigName
             + "|" + SharedAccessKeyConfigName + "|" + SharedAccessSignatureConfigName + "|" + EntityPathConfigName + "|" + OperationTimeoutConfigName
-            + "|" + TransportTypeConfigName + ")";
+            + "|" + TransportTypeConfigName + "|" + CustomHostnameConfigName + ")";
 
     private static final String KeysWithDelimitersRegex = KeyValuePairDelimiter + AllKeyEnumerateRegex
             + KeyValueSeparator;
 
     private URI endpoint;
     private String eventHubName;
+    private String customHostName;
     private String sharedAccessKeyName;
     private String sharedAccessKey;
     private String sharedAccessSignature;
@@ -112,6 +114,7 @@ public final class ConnectionStringBuilder {
         return this.endpoint;
     }
 
+
     /**
      * Set an endpoint which can be used to connect to the EventHub instance.
      *
@@ -123,6 +126,28 @@ public final class ConnectionStringBuilder {
     public ConnectionStringBuilder setEndpoint(URI endpoint) {
         this.endpoint = endpoint;
         return this;
+    }
+
+    /**
+     * Set an endpoint which can be used to connect to the EventHub instance.
+     *
+     * @param hostname Custom endpoint hostname without any prefixes, i.e. ehendpoint.mycompany.net
+     * @return the {@link ConnectionStringBuilder} being set.
+     */
+
+    public ConnectionStringBuilder setCustomHostName(String hostname) {
+        this.customHostName = hostname;
+        return this;
+    }
+
+    /**
+     * Get the custom endpoint host name from the connection string
+     *
+     * @return Custom endpoint host name
+     */
+
+    public String getCustomHostName() {
+        return this.customHostName;
     }
 
     /**
@@ -318,6 +343,11 @@ public final class ConnectionStringBuilder {
                     KeyValueSeparator, this.operationTimeout.toString(), KeyValuePairDelimiter));
         }
 
+        if (!StringUtil.isNullOrWhiteSpace(this.customHostName)) {
+            connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", CustomHostnameConfigName,
+                    KeyValueSeparator, this.customHostName, KeyValuePairDelimiter));
+        }
+
         if (this.transportType != null) {
             connectionStringBuilder.append(String.format(Locale.US, "%s%s%s%s", TransportTypeConfigName,
                     KeyValueSeparator, this.transportType.toString(), KeyValuePairDelimiter));
@@ -336,6 +366,7 @@ public final class ConnectionStringBuilder {
         final String connection = KeyValuePairDelimiter + connectionString;
 
         final Pattern keyValuePattern = Pattern.compile(KeysWithDelimitersRegex, Pattern.CASE_INSENSITIVE);
+
         final String[] values = keyValuePattern.split(connection);
         final Matcher keys = keyValuePattern.matcher(connection);
 
@@ -396,6 +427,8 @@ public final class ConnectionStringBuilder {
                 this.sharedAccessSignature = values[valueIndex];
             } else if (key.equalsIgnoreCase(EntityPathConfigName)) {
                 this.eventHubName = values[valueIndex];
+            } else if (key.equalsIgnoreCase(CustomHostnameConfigName)) {
+                this.customHostName = values[valueIndex];
             } else if (key.equalsIgnoreCase(OperationTimeoutConfigName)) {
                 try {
                     this.operationTimeout = Duration.parse(values[valueIndex]);

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/AmqpConnection.java
@@ -22,4 +22,10 @@ public interface AmqpConnection {
     void registerForConnectionError(Link link);
 
     void deregisterForConnectionError(Link link);
+
+    /**
+     * Custom host name intended to be used on Amqp Connection Open frame
+     * @return host name
+     */
+    String getCustomHostName();
 }

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/ConnectionHandler.java
@@ -109,7 +109,7 @@ public class ConnectionHandler extends BaseHandler {
      * @return host name
      */
     public String getRemoteHostName() {
-        return amqpConnection.getHostName();
+        return !StringUtil.isNullOrEmpty(amqpConnection.getCustomHostName()) ? amqpConnection.getCustomHostName() : amqpConnection.getHostName();
     }
 
     /**

--- a/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
+++ b/azure-eventhubs/src/main/java/com/microsoft/azure/eventhubs/impl/MessagingFactory.java
@@ -34,6 +34,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
 
     private static final Logger TRACE_LOGGER = LoggerFactory.getLogger(MessagingFactory.class);
     private final String hostName;
+    private final String customHost;
     private final CompletableFuture<Void> closeTask;
     private final ConnectionHandler connectionHandler;
     private final LinkedList<Link> registeredLinks;
@@ -62,6 +63,7 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
         super(StringUtil.getRandomString("MF"), null, executor);
 
         this.hostName = builder.getEndpoint().getHost();
+        this.customHost = builder.getCustomHostName();
         this.reactorFactory = reactorFactory;
         this.operationTimeout = builder.getOperationTimeout();
         this.retryPolicy = retryPolicy;
@@ -131,6 +133,11 @@ public final class MessagingFactory extends ClientEntity implements AmqpConnecti
     @Override
     public String getHostName() {
         return this.hostName;
+    }
+
+    @Override
+    public String getCustomHostName() {
+        return this.customHost;
     }
 
     private Reactor getReactor() {

--- a/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
+++ b/azure-eventhubs/src/test/java/com/microsoft/azure/eventhubs/connstrbuilder/ConnStrBuilderTest.java
@@ -15,15 +15,16 @@ import java.time.Duration;
 import java.util.function.Consumer;
 
 public class ConnStrBuilderTest extends ApiTestBase {
-    static final String correctConnectionString = "Endpoint=sb://endpoint1;EntityPath=eventhub1;SharedAccessKeyName=somevalue;SharedAccessKey=something;OperationTimeout=PT5S;TransportType=AMQP";
+    static final String correctConnectionString = "Endpoint=sb://endpoint1;EntityPath=eventhub1;SharedAccessKeyName=somevalue;SharedAccessKey=/something=;OperationTimeout=PT5S;CustomHostname=bla.blip.blop.windows.net;TransportType=AMQP";
     static final Consumer<ConnectionStringBuilder> validateConnStrBuilder = new Consumer<ConnectionStringBuilder>() {
         @Override
         public void accept(ConnectionStringBuilder connStrBuilder) {
             Assert.assertTrue(connStrBuilder.getEventHubName().equals("eventhub1"));
             Assert.assertTrue(connStrBuilder.getEndpoint().getHost().equals("endpoint1"));
-            Assert.assertTrue(connStrBuilder.getSasKey().equals("something"));
+            Assert.assertTrue(connStrBuilder.getSasKey().equals("/something="));
             Assert.assertTrue(connStrBuilder.getSasKeyName().equals("somevalue"));
             Assert.assertTrue(connStrBuilder.getTransportType() == TransportType.AMQP);
+            Assert.assertTrue(connStrBuilder.getCustomHostName().equals("bla.blip.blop.windows.net"));
             Assert.assertTrue(connStrBuilder.getOperationTimeout().equals(Duration.ofSeconds(5)));
         }
     };
@@ -61,6 +62,7 @@ public class ConnStrBuilderTest extends ApiTestBase {
                 .setSasKeyName(connStrBuilder.getSasKeyName())
                 .setSasKey(connStrBuilder.getSasKey())
                 .setTransportType(connStrBuilder.getTransportType())
+                .setCustomHostName(connStrBuilder.getCustomHostName())
                 .setOperationTimeout(connStrBuilder.getOperationTimeout());
 
         validateConnStrBuilder.accept(new ConnectionStringBuilder(secondConnStr.toString()));


### PR DESCRIPTION
## Description
In a case where you need to use custom DNS name for a private EventHub
endpoint and do not have the ability to setup up DNS forwarding from
on-premise to Azure DNS you need to split the Endpoint namespace name
from the actual hostname to connect to.

This PR introduces such an ability by adding `CustomHostname`
ConnectionString parameter.
-->

This checklist is used to make sure that common guidelines for a pull request are followed.

- [x] **I have read the [contribution guidelines](./CONTRIBUTING.md).**
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR.
- [x] The pull request does not introduce breaking changes (unless a major version change occurs in the assembly and module).
- [x] If applicable, the public code is properly documented.
- [x] Pull request includes test coverage for the included changes.
- [x] The code builds without any errors.